### PR TITLE
gemini-bbox-tool: Top-left is (0,0) instead of Bottom-right

### DIFF
--- a/gemini-bbox-tool.html
+++ b/gemini-bbox-tool.html
@@ -89,7 +89,7 @@
 
                     const colors = ['#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#FF00FF', '#00FFFF'];
                     coordinates.forEach((box, index) => {
-                        const [ymin, xmin, ymax, xmax] = box.map(coord => (1000 - coord) / 1000);
+                        const [ymin, xmin, ymax, xmax] = box.map(coord => coord / 1000);
                         const width = (xmax - xmin) * image.width;
                         const height = (ymax - ymin) * image.height;
 


### PR DESCRIPTION
Currently, I'm seeing the boxes as being drawn with the coordinates inversed, as if the bottom-right is (0,0).