### PR TITLE
[youtube-thumbnails] Split thumbnail types and qualities

### DIFF
--- a/youtube-thumbnails.html
+++ b/youtube-thumbnails.html
@@ -76,23 +76,26 @@
             const input = document.getElementById("videoInput").value.trim();
             const videoID = extractVideoID(input);
             if (videoID.length === 11) {
-                const imageTypes = ['default', 'hqdefault', 'mqdefault', 'sddefault', 'maxresdefault', '0', '1', '2', '3'];
+                const imageTypes = ['default', '1', '2', '3'];
+                const imageQuality = ['', 'mq', 'hq', 'sd', 'maxres'];
                 const container = document.getElementById("thumbnails");
                 container.innerHTML = '';
 
                 imageTypes.forEach(type => {
-                    const imageUrl = `https://img.youtube.com/vi/${videoID}/${type}.jpg`;
-                    const thumbnailHTML = `
-                        <div class="thumbnail">
-                            <img src="${imageUrl}" alt="Thumbnail ${type}" onclick="toggleExpand(this)">
-                            <p class="image-size"></p>
-                            <div class="thumbnail-url" onclick="copyText('${imageUrl}')">
-                                <span class="copy-icon">📋</span>
-                                <span>${imageUrl}</span>
+                    imageQuality.forEach(quality => {
+                        const imageUrl = `https://img.youtube.com/vi/${videoID}/${quality}${type}.jpg`;
+                        const thumbnailHTML = `
+                            <div class="thumbnail">
+                                <img src="${imageUrl}" alt="Thumbnail ${type}" onclick="toggleExpand(this)">
+                                <p class="image-size"></p>
+                                <div class="thumbnail-url" onclick="copyText('${imageUrl}')">
+                                    <span class="copy-icon">📋</span>
+                                    <span>${imageUrl}</span>
+                                </div>
                             </div>
-                        </div>
-                    `;
-                    container.innerHTML += thumbnailHTML;
+                        `;
+                        container.innerHTML += thumbnailHTML;
+                    });
                 });
 
                 // Get actual image sizes after they've loaded


### PR DESCRIPTION
Every type (except for the special "0") is available in 5 quality levels. Loop over them and show all of them on the page.

This hides the special "0" type image. This is an alias for default, but only exposes a single quality level ("").

Could also hardcode all the variants in one array, or first calculate a product of the two arrays, if you really do not want a nested `forEach`. But I did not feel too bad to go the easy way for a single HTML file tool 😊