### PR TITLE
Add latest Gemini models

### DIFF
--- a/gemini-bbox.html
+++ b/gemini-bbox.html
@@ -312,6 +312,9 @@
 <body>
     <h1>Gemini API Image Bounding Box Visualization</h1>
     <select id="modelSelect">
+        <option value="gemini-2.5-flash">gemini-2.5-flash (default)</option>
+        <option value="gemini-2.5-pro">gemini-2.5-pro</option>
+        <option value="gemini-2.5-flash-lite-preview-06-17">gemini-2.5-flash-lite-preview-06-17</option>
         <option value="gemini-2.5-flash-preview-04-17">gemini-2.5-flash-preview-04-17</option>
         <option value="gemini-2.5-pro-exp-03-25">gemini-2.5-pro-exp-03-25</option>
         <option value="gemini-2.5-pro-preview-03-25">gemini-2.5-pro-preview-03-25</option>

--- a/gemini-chat.html
+++ b/gemini-chat.html
@@ -179,6 +179,9 @@
 <body>
     <h1>Gemini Chat App</h1>
     <select id="model-select">
+        <option value="gemini-2.5-flash">gemini-2.5-flash (default)</option>
+        <option value="gemini-2.5-pro">gemini-2.5-pro</option>
+        <option value="gemini-2.5-flash-lite-preview-06-17">gemini-2.5-flash-lite-preview-06-17</option>
         <option value="gemini-2.0-flash-exp">gemini-2.0-flash-exp</option>
         <option value="gemini-1.5-pro-latest">gemini-1.5-pro</option>
         <option value="gemini-1.5-flash-latest">gemini-1.5-flash</option>

--- a/gemini-mask.html
+++ b/gemini-mask.html
@@ -368,6 +368,9 @@
 <body>
   <h1>Gemini API Image Mask Visualization</h1>
   <select id="modelSelect">
+    <option value="gemini-2.5-flash">gemini-2.5-flash (default)</option>
+    <option value="gemini-2.5-pro">gemini-2.5-pro</option>
+    <option value="gemini-2.5-flash-lite-preview-06-17">gemini-2.5-flash-lite-preview-06-17</option>
     <option value="gemini-2.5-flash-preview-04-17" data-non-thinking="true">
       gemini-2.5-flash-preview-04-17 (non thinking)
     </option>


### PR DESCRIPTION
## Summary
- add gemini-2.5-flash, gemini-2.5-pro and gemini-2.5-flash-lite-preview-06-17 as first options in model dropdowns

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_685206b944c88326a8ce73ae2a696b99