### PR TITLE
Fix Open Sauce schedule dates

### DIFF
--- a/open-sauce-2025.docs.md
+++ b/open-sauce-2025.docs.md
@@ -1,3 +1,3 @@
-This page displays the schedule for the Open Sauce 2025 conference taking place July 25-27, 2025. The schedule is organized by day (Friday, Saturday, Sunday) with each session showing time, location, description, and speaker information. Users can download the complete schedule as an ICS calendar file for integration with their calendar applications.
+This page displays the schedule for the Open Sauce 2025 conference taking place July 18-20, 2025. The schedule is organized by day (Friday, Saturday, Sunday) with each session showing time, location, description, and speaker information. Users can download the complete schedule as an ICS calendar file for integration with their calendar applications.
 
 <!-- Generated from commit: bb5b4b49b2a38729eca39a51cb13cb3eae07978e -->

--- a/open-sauce-2025.html
+++ b/open-sauce-2025.html
@@ -220,14 +220,14 @@
     <div class="container">
         <div class="header">
             <h1>Open Sauce 2025</h1>
-            <p>July 25-27, 2025</p>
+            <p>July 18-20, 2025</p>
             <button class="download-btn" onclick="downloadICS()">📅 Download Calendar (ICS)</button>
         </div>
 
         <div class="day-tabs">
-            <button class="day-tab active" onclick="showDay('friday')">Friday 25th</button>
-            <button class="day-tab" onclick="showDay('saturday')">Saturday 26th</button>
-            <button class="day-tab" onclick="showDay('sunday')">Sunday 27th</button>
+            <button class="day-tab active" onclick="showDay('friday')">Friday 18th</button>
+            <button class="day-tab" onclick="showDay('saturday')">Saturday 19th</button>
+            <button class="day-tab" onclick="showDay('sunday')">Sunday 20th</button>
         </div>
 
         <div class="loading" id="loading">Loading schedule...</div>
@@ -355,9 +355,9 @@
 
         function generateICS() {
             const dayDates = {
-                friday: '20250725',
-                saturday: '20250726',
-                sunday: '20250727'
+                friday: '20250718',
+                saturday: '20250719',
+                sunday: '20250720'
             };
 
             let icsContent = `BEGIN:VCALENDAR


### PR DESCRIPTION
## Summary
- correct July dates for Open Sauce 2025 in docs and HTML
- update day tab labels and ICS generation dates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_68793939c7088326a376a88c11af6544