### PR TITLE
Remove speaker avatars

### DIFF
--- a/open-sauce-2025.html
+++ b/open-sauce-2025.html
@@ -167,12 +167,6 @@
             font-size: 0.9rem;
         }
 
-        .speaker-avatar {
-            width: 24px;
-            height: 24px;
-            border-radius: 50%;
-            background: #667eea;
-        }
 
         .length-badge {
             background: #ffc107;
@@ -278,7 +272,6 @@
                             <div class="speakers">
                                 ${session.speakers.map(speaker => `
                                     <div class="speaker">
-                                        <img src="${speaker.media}" alt="${speaker.name}" class="speaker-avatar" onerror="this.style.display='none'">
                                         <span>${speaker.name}</span>
                                     </div>
                                 `).join('')}
@@ -287,7 +280,6 @@
                         ${session.moderator ? `
                             <div class="speakers">
                                 <div class="speaker" style="background: #e3f2fd;">
-                                    <img src="${session.moderator.media}" alt="${session.moderator.name}" class="speaker-avatar" onerror="this.style.display='none'">
                                     <span><strong>Moderator:</strong> ${session.moderator.name}</span>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
- clean up speaker card layout for Open Sauce 2025 schedule
- drop avatar images from the sessions list

## Testing
- `pytest -q` *(fails: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_6879621187908326a5688e66fa7d0832