### PR TITLE
Improve image-to-jpeg mobile layout

### DIFF
--- a/image-to-jpeg.html
+++ b/image-to-jpeg.html
@@ -4,23 +4,31 @@
   <title>Drag and Drop Image</title>
   <style>
     #dropzone {
-      width: 500px;
+      width: min(100%, 500px);
       height: 100px;
       border: 2px dashed #ccc;
       text-align: center;
       padding: 20px;
       margin-bottom: 20px;
+      margin-left: auto;
+      margin-right: auto;
     }
     #output {
-      width: 500px;
+      width: min(100%, 500px);
       margin-bottom: 20px;
+      display: block;
+      margin-left: auto;
+      margin-right: auto;
     }
     textarea {
-      width: 500px;
+      width: min(100%, 500px);
       height: 100px;
     }
     .container {
       margin-bottom: 20px;
+    }
+    #jpegSize {
+      margin-top: 10px;
     }
     #fileInput {
       display: none;
@@ -33,13 +41,13 @@
   <div class="container">
     <label for="qualityRange">JPEG Quality: <span id="qualityValue">75</span></label><br>
     <input type="range" id="qualityRange" min="0" max="100" value="75" />
+    <div id="jpegSize">JPEG Size: 0 bytes</div>
   </div>
   <img id="output" src="" alt="Converted Image" /><br>
   <div class="container">
     <label for="imgDataUri">Image Data URI:</label><br>
     <textarea id="imgDataUri" readonly></textarea>
   </div>
-  <div id="jpegSize">JPEG Size: 0 bytes</div>
 
   <script>
     const dropzone = document.getElementById('dropzone');


### PR DESCRIPTION
## Summary
- make the image-to-jpeg tool responsive
- show JPEG size below the slider

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_68798cf9d0b48326a4fd76f136b6c9eb