### PR TITLE
Add blog link to Open Sauce page

### DIFF
--- a/open-sauce-2025.docs.md
+++ b/open-sauce-2025.docs.md
@@ -1,3 +1,3 @@
 This webpage displays the schedule for the Open Sauce 2025 conference taking place from July 18-20, 2025. The interface organizes sessions by day with tabs for Friday, Saturday, and Sunday, showing event details including time, location, speakers, and descriptions for each session. Users can download the complete schedule as an ICS calendar file to add conference events to their personal calendars.
 
-<!-- Generated from commit: 7127a8c2e4e56b14b33840cc4f679f8ed657a548 -->
+<!-- Generated from commit: be767ba0164d0799db284f65fd4a28f389a659b4 -->

--- a/open-sauce-2025.html
+++ b/open-sauce-2025.html
@@ -222,6 +222,7 @@
             <h1>Open Sauce 2025</h1>
             <p>July 18-20, 2025</p>
             <button class="download-btn" onclick="downloadICS()">📅 Download Calendar (ICS)</button>
+            <p style="margin-top: 10px;"><a href="https://simonwillison.net/2025/Jul/17/vibe-scraping/">How I built this</a></p>
         </div>
 
         <div class="day-tabs">

--- a/open-sauce-2025.html
+++ b/open-sauce-2025.html
@@ -222,7 +222,7 @@
             <h1>Open Sauce 2025</h1>
             <p>July 18-20, 2025</p>
             <button class="download-btn" onclick="downloadICS()">📅 Download Calendar (ICS)</button>
-            <p style="margin-top: 10px;"><a href="https://simonwillison.net/2025/Jul/17/vibe-scraping/">How I built this</a></p>
+            <p style="margin-top: 10px;"><a href="https://simonwillison.net/2025/Jul/17/vibe-scraping/" style="color: white">How I built this</a></p>
         </div>
 
         <div class="day-tabs">


### PR DESCRIPTION
## Summary
- link to blog post on how the page was built
- update docs commit reference

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_687951b3ce6c8326be8d0f1d5518a918