### PR TITLE
Improve schedule search results display

### DIFF
--- a/open-sauce-2025.html
+++ b/open-sauce-2025.html
@@ -230,6 +230,21 @@
             margin: 20px 0;
         }
 
+        .day-heading {
+            display: none;
+            color: white;
+            text-align: center;
+            margin: 20px 0 10px;
+        }
+
+        .searching .day-tabs {
+            display: none;
+        }
+
+        .searching .day-heading {
+            display: block;
+        }
+
         @media (max-width: 768px) {
             .container {
                 padding: 15px;
@@ -277,8 +292,13 @@
 
         <div class="loading" id="loading" role="status" aria-live="polite">Loading schedule...</div>
 
+        <h2 class="day-heading">Friday 18th</h2>
         <div id="friday" class="day-content active" role="tabpanel" aria-labelledby="tab-friday"></div>
+
+        <h2 class="day-heading">Saturday 19th</h2>
         <div id="saturday" class="day-content" role="tabpanel" aria-labelledby="tab-saturday" aria-hidden="true"></div>
+
+        <h2 class="day-heading">Sunday 20th</h2>
         <div id="sunday" class="day-content" role="tabpanel" aria-labelledby="tab-sunday" aria-hidden="true"></div>
     </div>
 
@@ -539,7 +559,22 @@ END:VEVENT
         }
 
         document.getElementById('searchInput').addEventListener('input', e => {
-            renderSchedule(e.target.value);
+            const filter = e.target.value;
+            renderSchedule(filter);
+
+            const container = document.querySelector('.container');
+            if (filter.trim()) {
+                container.classList.add('searching');
+                document.querySelectorAll('.day-content').forEach(content => {
+                    content.classList.add('active');
+                    content.setAttribute('aria-hidden', 'false');
+                });
+            } else {
+                container.classList.remove('searching');
+                const activeTab = document.querySelector('.day-tab.active') || document.getElementById('tab-friday');
+                const day = activeTab.id.replace('tab-', '');
+                showDay(day, { currentTarget: activeTab });
+            }
         });
 
         // Load schedule when page loads


### PR DESCRIPTION
## Summary
- show day headings when searching the Open Sauce 2025 schedule
- hide day tabs when filtering results
- display sessions from all days during search

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_687ac528b7208326a92c48ced996838d