### PR TITLE
Update schedule URL for Open Sauce 2025

### DIFF
--- a/open-sauce-2025.html
+++ b/open-sauce-2025.html
@@ -308,7 +308,7 @@
 
         async function loadSchedule() {
             try {
-                const response = await fetch('https://raw.githubusercontent.com/simonw/.github/f671bf57f7c20a4a7a5b0642837811e37c557499/schedule.json');
+                const response = await fetch('https://raw.githubusercontent.com/simonw/.github/efd800df75d2804e502b2f8563503f669747dec5/schedule.json');
                 if (!response.ok) {
                     throw new Error(`HTTP error! status: ${response.status}`);
                 }


### PR DESCRIPTION
## Summary
- update Open Sauce 2025 schedule URL to the latest commit

## Testing
- `pytest -q` *(fails: Locator expected to have Value 'eng')*

------
https://chatgpt.com/codex/tasks/task_e_687bd559a9948326a005dec9ae80d895