### PR TITLE
Fix stray backticks in speech synthesis page

### DIFF
--- a/speech-synthesis.html
+++ b/speech-synthesis.html
@@ -159,7 +159,6 @@ color: #0c5460;
   <div class="container">
     <h1>Speech synthesis tester</h1>
 
-```
 <div class="form-group">
   <label for="textInput">Text to speak:</label>
   <textarea id="textInput" placeholder="Enter text to be spoken...">Hello, this is a test of the speech synthesis API!</textarea>
@@ -198,7 +197,6 @@ color: #0c5460;
 </div>
 
 <div class="status ready" id="status">Ready to speak</div>
-```
 
   </div>
 


### PR DESCRIPTION
## Summary
- clean up stray backticks in `speech-synthesis.html`

## Testing
- `pytest -q` *(fails: Locator expected to have Value 'eng')*

------
https://chatgpt.com/codex/tasks/task_e_687fc560d74c8326a58cf1d1e6735c9d