### PR TITLE
Expand colophon entries based on URL fragment

### DIFF
--- a/build_colophon.py
+++ b/build_colophon.py
@@ -274,8 +274,22 @@ def build_colophon():
     </div>
 """
 
-    # Close the HTML
+    # Close the HTML with script that expands the correct tool
     html_content += """
+    <script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const hash = window.location.hash.slice(1);
+        if (hash) {
+            const element = document.getElementById(hash);
+            if (element) {
+                const details = element.querySelector('details');
+                if (details) {
+                    details.open = true;
+                }
+            }
+        }
+    });
+    </script>
 </body>
 </html>
 """


### PR DESCRIPTION
## Summary
- open the relevant tool's development history if the colophon is loaded with a fragment identifier

------
https://chatgpt.com/s/cd_68ba01ddab7c819182005c5994b10aec