### PR TITLE
feat: add padding to drop zone

### DIFF
--- a/image-resize-quality.html
+++ b/image-resize-quality.html
@@ -18,6 +18,8 @@
       border-radius: 20px;
       width: 100%;
       min-height: 200px;
+      padding: 20px;
+      box-sizing: border-box;
       display: flex;
       justify-content: center;
       align-items: center;


### PR DESCRIPTION
## Summary
- add 20px padding to image upload drop zone and enforce border-box sizing so text doesn't touch edges

## Testing
- `pytest` *(fails: BrowserType.launch: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68bc705148c483268644dc1eea65e824