### PR TITLE
Adjust mobile search icon spacing

### DIFF
--- a/homepage-search.js
+++ b/homepage-search.js
@@ -168,9 +168,12 @@ ready(() => {
         margin: 1.25rem 0 1.75rem;
         padding: 0.85rem 0.75rem;
       }
+      .tool-search-input-icon {
+        left: 0.85rem;
+      }
       #tool-search-input {
         font-size: 1.05rem;
-        padding: 0.8rem 0.9rem;
+        padding: 0.8rem 0.9rem 0.8rem 2.55rem;
       }
       .tool-search-option-link {
         padding: 0.7rem 0.8rem 0.75rem;


### PR DESCRIPTION
## Summary
- adjust the mobile search input icon offset to prevent overlap with the placeholder text
- restore left-side padding on the mobile search input so text clears the icon

## Testing
- no tests were run

------
https://chatgpt.com/s/cd_68d570bcdb388191a9b3ae953239aa7b