### PR TITLE
Trim SVG input to root element before rendering

### DIFF
--- a/svg-render.html
+++ b/svg-render.html
@@ -237,11 +237,17 @@
             downloadLink.style.display = 'none';
             fileSizeSpan.textContent = '';
 
-            // Find the <?xml tag and ignore everything before it
-            const xmlIndex = svgContent.indexOf('<?xml');
-            if (xmlIndex !== -1) {
-                svgContent = svgContent.substring(xmlIndex);
+            // Extract the SVG element, ignoring any surrounding content
+            const lowerContent = svgContent.toLowerCase();
+            const svgStart = lowerContent.indexOf('<svg');
+            const svgEnd = lowerContent.lastIndexOf('</svg>');
+
+            if (svgStart === -1 || svgEnd === -1) {
+                alert('Invalid SVG input');
+                return;
             }
+
+            svgContent = svgContent.slice(svgStart, svgEnd + '</svg>'.length);
 
             // Create a temporary SVG element
             const svgElement = new DOMParser().parseFromString(svgContent, 'image/svg+xml').documentElement;


### PR DESCRIPTION
## Summary
- extract the root <svg> element from provided text before parsing it
- ensure content before or after the SVG markup is ignored during rendering

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e07e7baec0832685cc03c580efaec1