### PR TITLE
Add query-string-stripper.html tool

### DIFF
--- a/query-string-stripper.html
+++ b/query-string-stripper.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Query String Stripper</title>
+    <style>
+        * {
+            box-sizing: border-box;
+        }
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        h1 {
+            margin-bottom: 10px;
+        }
+        p {
+            margin-top: 0;
+            color: #666;
+        }
+        label {
+            display: block;
+            margin-bottom: 5px;
+            font-weight: bold;
+        }
+        #url-input {
+            width: 100%;
+            padding: 10px;
+            border: 1px solid #ccc;
+            font-size: 16px;
+            margin-bottom: 20px;
+        }
+        #output-container {
+            display: none;
+            background-color: #f0f0f0;
+            padding: 15px;
+            border-radius: 5px;
+            margin-bottom: 15px;
+        }
+        #output-container.visible {
+            display: block;
+        }
+        #stripped-url {
+            width: 100%;
+            padding: 10px;
+            border: 1px solid #ccc;
+            background-color: #fff;
+            font-size: 16px;
+            margin-bottom: 10px;
+            word-break: break-all;
+        }
+        #copy-button {
+            padding: 10px 20px;
+            cursor: pointer;
+            background-color: #007bff;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            font-size: 16px;
+        }
+        #copy-button:hover {
+            background-color: #0056b3;
+        }
+        #copy-button:active {
+            background-color: #004085;
+        }
+        @media (max-width: 600px) {
+            body {
+                padding: 10px;
+            }
+            h1 {
+                font-size: 24px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <h1>Query String Stripper</h1>
+    <p>Paste a URL to remove the query string (everything from ? onwards)</p>
+
+    <label for="url-input">URL:</label>
+    <input type="text" id="url-input" placeholder="https://example.com/page?param1=value1&param2=value2">
+
+    <div id="output-container">
+        <label for="stripped-url">Stripped URL:</label>
+        <input type="text" id="stripped-url" readonly>
+        <button id="copy-button">Copy to clipboard</button>
+    </div>
+
+    <script>
+        const urlInput = document.getElementById('url-input');
+        const outputContainer = document.getElementById('output-container');
+        const strippedUrl = document.getElementById('stripped-url');
+        const copyButton = document.getElementById('copy-button');
+
+        function stripQueryString(url) {
+            const questionMarkIndex = url.indexOf('?');
+            if (questionMarkIndex === -1) {
+                return url;
+            }
+            return url.substring(0, questionMarkIndex);
+        }
+
+        urlInput.addEventListener('input', function() {
+            const inputValue = urlInput.value.trim();
+
+            if (inputValue) {
+                const stripped = stripQueryString(inputValue);
+                strippedUrl.value = stripped;
+                outputContainer.classList.add('visible');
+            } else {
+                outputContainer.classList.remove('visible');
+            }
+        });
+
+        copyButton.addEventListener('click', function() {
+            strippedUrl.select();
+            strippedUrl.setSelectionRange(0, 99999); // For mobile devices
+
+            navigator.clipboard.writeText(strippedUrl.value).then(() => {
+                const originalText = copyButton.textContent;
+                copyButton.textContent = 'Copied!';
+
+                setTimeout(() => {
+                    copyButton.textContent = originalText;
+                }, 1500);
+            }).catch(() => {
+                // Fallback for older browsers
+                document.execCommand('copy');
+                const originalText = copyButton.textContent;
+                copyButton.textContent = 'Copied!';
+
+                setTimeout(() => {
+                    copyButton.textContent = originalText;
+                }, 1500);
+            });
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Creates a mobile-friendly interface for stripping query strings from URLs. As users paste or type a URL, it instantly displays the URL with everything from ? onwards removed, plus a copy to clipboard button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)