### PR TITLE
Add Esc key functionality to close side panel

### DIFF
--- a/side-panel-dialog.html
+++ b/side-panel-dialog.html
@@ -262,9 +262,10 @@
 // Fix animation issues with dialog element
 document.addEventListener('DOMContentLoaded', () => {
   const dialog = document.getElementById('sidePanel');
-  // Force browser to recognize dialog animations by adding a small delay
+  // Handle Esc key to close the dialog with animation
   dialog.addEventListener('cancel', (event) => {
     event.preventDefault();
+    animateCloseDialog();
   });
 });
 


### PR DESCRIPTION
- Modified cancel event listener to trigger animateCloseDialog()
- Esc key now closes the panel with proper slide-out animation
- Maintains consistency with other close methods (X button, backdrop click)

🤖 Generated with [Claude Code](https://claude.com/claude-code)