### PR TITLE
Remove thick border from social-media-cropper generated images

### DIFF
--- a/social-media-cropper.html
+++ b/social-media-cropper.html
@@ -486,7 +486,7 @@
             const scale = Math.min(
                 canvas.width / croppedCanvas.width,
                 canvas.height / croppedCanvas.height
-            ) * 0.95; // Scale slightly down to add padding
+            );
             
             const scaledWidth = croppedCanvas.width * scale;
             const scaledHeight = croppedCanvas.height * scale;


### PR DESCRIPTION
Changed scale factor from 0.95 to 1.0 to eliminate the padding/border around cropped images. Images now fill the entire canvas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)