### PR TITLE
Add Gist Privacy Checkbox to Terminal Tool

### DIFF
--- a/terminal-to-html.html
+++ b/terminal-to-html.html
@@ -447,13 +447,20 @@ function checkGithubAuth() {
   const token = localStorage.getItem('github_token');
   const authLinkContainer = document.getElementById('authLinkContainer');
   const saveGistBtn = document.getElementById('saveGistBtn');
+  const privateGistLabel = document.getElementById('privateGistLabel');
 
   if (token && authLinkContainer && saveGistBtn) {
     authLinkContainer.style.display = 'none';
     saveGistBtn.style.display = 'inline-block';
+    if (privateGistLabel) {
+      privateGistLabel.style.display = 'inline-flex';
+    }
   } else if (authLinkContainer && saveGistBtn) {
     authLinkContainer.style.display = 'inline';
     saveGistBtn.style.display = 'none';
+    if (privateGistLabel) {
+      privateGistLabel.style.display = 'none';
+    }
   }
 }
 
@@ -475,6 +482,8 @@ async function createGist(htmlContent) {
 
   const saveGistBtn = document.getElementById('saveGistBtn');
   const gistLinks = document.getElementById('gistLinks');
+  const privateGistCheckbox = document.getElementById('privateGistCheckbox');
+  const isPrivate = privateGistCheckbox ? privateGistCheckbox.checked : true;
 
   try {
     saveGistBtn.disabled = true;
@@ -488,7 +497,7 @@ async function createGist(htmlContent) {
       },
       body: JSON.stringify({
         description: 'Terminal output HTML',
-        public: true,
+        public: !isPrivate,
         files: {
           'index.html': {
             content: htmlContent
@@ -614,6 +623,10 @@ pasteArea.addEventListener('paste', async (e) => {
         <button id="authLink">Authenticate with GitHub</button>
       </span>
       <button id="saveGistBtn" style="display: none;">Save this to a Gist</button>
+      <label id="privateGistLabel" style="display: none; color: #0f0; align-items: center; cursor: pointer; font-size: 14px; margin-left: 10px;">
+        <input type="checkbox" id="privateGistCheckbox" checked style="margin-right: 5px; cursor: pointer;">
+        Private Gist
+      </label>
     </div>
     <textarea class="code-output" id="htmlOutput" readonly>${escapeHtml(fullHtml)}</textarea>
     <div id="gistLinks" class="gist-links" style="display: none;"></div>


### PR DESCRIPTION
- Added a "Private Gist" checkbox that defaults to checked
- Checkbox appears alongside the "Save this to a Gist" button
- Updated createGist function to respect the checkbox value
- Private gists are now the default behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)