### PR TITLE
Redesign GitHub Rate Limit Display

### DIFF
--- a/github-issue.html
+++ b/github-issue.html
@@ -119,7 +119,7 @@
 
         // Load token from localStorage on page load
         document.addEventListener('DOMContentLoaded', () => {
-            const savedToken = localStorage.getItem('githubToken');
+            const savedToken = localStorage.getItem('GITHUB_TOKEN');
             if (savedToken) {
                 tokenInput.value = savedToken;
             }
@@ -129,9 +129,9 @@
         tokenInput.addEventListener('input', () => {
             const token = tokenInput.value.trim();
             if (token) {
-                localStorage.setItem('githubToken', token);
+                localStorage.setItem('GITHUB_TOKEN', token);
             } else {
-                localStorage.removeItem('githubToken');
+                localStorage.removeItem('GITHUB_TOKEN');
             }
         });
 

--- a/github-ratelimit.html
+++ b/github-ratelimit.html
@@ -10,170 +10,170 @@
 }
 
 body {
-  font-family: 'Courier New', Courier, monospace;
-  max-width: 900px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+  max-width: 1000px;
   margin: 0 auto;
   padding: 20px;
-  background: #000;
-  color: #0f0;
+  background: #f6f8fa;
+  color: #24292f;
   line-height: 1.6;
 }
 
 h1 {
-  color: #0f0;
+  color: #24292f;
   margin-bottom: 10px;
-  font-weight: bold;
-  text-shadow: 0 0 10px #0f0;
+  font-weight: 600;
+  font-size: 32px;
 }
 
 .instructions {
-  background: #001a00;
-  border-left: 4px solid #0f0;
+  background: #ddf4ff;
+  border-left: 4px solid #0969da;
   padding: 15px;
   margin-bottom: 20px;
-  border-radius: 4px;
-  color: #0f0;
+  border-radius: 6px;
+  color: #0969da;
 }
 
 .auth-section {
-  background: #001a00;
-  border-radius: 8px;
-  border: 1px solid #0f0;
+  background: #ffffff;
+  border-radius: 6px;
+  border: 1px solid #d0d7de;
   padding: 20px;
-  box-shadow: 0 0 20px rgba(0, 255, 0, 0.2);
   margin-bottom: 20px;
   text-align: center;
 }
 
 .results {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-}
-
-.section {
-  background: #001a00;
-  border-radius: 8px;
-  border: 1px solid #0f0;
+  background: #ffffff;
+  border-radius: 6px;
+  border: 1px solid #d0d7de;
   padding: 20px;
-  box-shadow: 0 0 20px rgba(0, 255, 0, 0.2);
+  margin-bottom: 20px;
 }
 
-.section h2 {
+.results h2 {
   margin-top: 0;
-  color: #0f0;
-  font-size: 18px;
-  border-bottom: 2px solid #0f0;
-  padding-bottom: 10px;
+  color: #24292f;
+  font-size: 20px;
+  font-weight: 600;
   margin-bottom: 15px;
-  text-shadow: 0 0 5px #0f0;
 }
 
-.rate-limit-grid {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 15px;
-  align-items: center;
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 20px;
 }
 
-.rate-limit-label {
-  font-weight: bold;
-  color: #0c0;
-  text-align: right;
-  padding-right: 15px;
+thead {
+  background: #f6f8fa;
 }
 
-.rate-limit-value {
-  color: #0f0;
-  font-size: 18px;
-  padding: 8px 12px;
-  background: #000;
-  border: 1px solid #0f0;
-  border-radius: 4px;
+th {
+  text-align: left;
+  padding: 12px;
+  font-weight: 600;
+  color: #57606a;
+  border-bottom: 2px solid #d0d7de;
+  font-size: 14px;
 }
 
-.rate-limit-value.warning {
-  color: #ff0;
-  border-color: #ff0;
-  text-shadow: 0 0 5px #ff0;
+td {
+  padding: 12px;
+  border-bottom: 1px solid #d0d7de;
+  font-size: 14px;
 }
 
-.rate-limit-value.critical {
-  color: #f00;
-  border-color: #f00;
-  text-shadow: 0 0 5px #f00;
+tr:last-child td {
+  border-bottom: none;
+}
+
+tbody tr:hover {
+  background: #f6f8fa;
+}
+
+.resource-name {
+  font-weight: 600;
+  color: #24292f;
+}
+
+.number {
+  font-variant-numeric: tabular-nums;
+}
+
+.warning {
+  color: #9a6700;
+  font-weight: 600;
+}
+
+.critical {
+  color: #cf222e;
+  font-weight: 600;
+}
+
+.ditto {
+  color: #57606a;
+  text-align: center;
 }
 
 button {
-  padding: 15px 30px;
-  background: #0f0;
-  color: #000;
-  border: none;
-  border-radius: 4px;
+  padding: 10px 20px;
+  background: #2da44e;
+  color: #ffffff;
+  border: 1px solid rgba(27, 31, 36, 0.15);
+  border-radius: 6px;
   cursor: pointer;
-  font-size: 16px;
-  font-family: 'Courier New', Courier, monospace;
-  font-weight: bold;
-  transition: all 0.3s;
-  box-shadow: 0 0 10px rgba(0, 255, 0, 0.3);
+  font-size: 14px;
+  font-weight: 500;
+  transition: all 0.2s;
 }
 
 button:hover {
-  background: #0c0;
-  box-shadow: 0 0 20px rgba(0, 255, 0, 0.5);
+  background: #2c974b;
 }
 
 button:active {
-  background: #0a0;
+  background: #298e46;
 }
 
 button:disabled {
-  background: #333;
-  color: #666;
+  background: #94d3a2;
   cursor: not-allowed;
-  box-shadow: none;
 }
 
 .error {
-  background: #1a0000;
-  border-left: 4px solid #f00;
+  background: #ffebe9;
+  border-left: 4px solid #cf222e;
   padding: 15px;
   margin-bottom: 20px;
-  border-radius: 4px;
-  color: #f00;
-}
-
-.empty-state {
-  text-align: center;
-  color: #0a0;
-  padding: 40px;
-  font-size: 18px;
+  border-radius: 6px;
+  color: #cf222e;
 }
 
 #authLink {
-  color: #0f0;
+  color: #0969da;
   cursor: pointer;
   text-decoration: underline;
   background: none;
   border: none;
   padding: 0;
   font-size: inherit;
-  box-shadow: none;
   display: inline;
 }
 
 #authLink:hover {
-  color: #0ff;
-  text-shadow: 0 0 5px #0ff;
+  color: #0550ae;
 }
 
 .timestamp {
-  color: #0a0;
-  font-size: 14px;
+  color: #57606a;
+  font-size: 12px;
   font-style: italic;
   margin-top: 15px;
   padding-top: 15px;
-  border-top: 1px solid #0a0;
+  border-top: 1px solid #d0d7de;
+  text-align: right;
 }
 
 @media (max-width: 768px) {
@@ -185,14 +185,12 @@ button:disabled {
     font-size: 24px;
   }
 
-  .rate-limit-grid {
-    grid-template-columns: 1fr;
-    gap: 10px;
+  table {
+    font-size: 12px;
   }
 
-  .rate-limit-label {
-    text-align: left;
-    padding-right: 0;
+  th, td {
+    padding: 8px;
   }
 }
   </style>
@@ -213,7 +211,7 @@ button:disabled {
     <button id="checkRateLimitBtn">Check Rate Limit</button>
   </div>
 
-  <div class="results" id="results"></div>
+  <div id="results"></div>
 
 <script type="module">
 const authSection = document.getElementById('authSection');
@@ -223,7 +221,7 @@ const checkRateLimitBtn = document.getElementById('checkRateLimitBtn');
 const resultsDiv = document.getElementById('results');
 
 function checkGithubAuth() {
-  const token = localStorage.getItem('github_token');
+  const token = localStorage.getItem('GITHUB_TOKEN');
 
   if (token) {
     authSection.style.display = 'none';
@@ -236,7 +234,7 @@ function checkGithubAuth() {
 
 function startAuthPoll() {
   const pollInterval = setInterval(() => {
-    if (localStorage.getItem('github_token')) {
+    if (localStorage.getItem('GITHUB_TOKEN')) {
       checkGithubAuth();
       clearInterval(pollInterval);
     }
@@ -282,7 +280,7 @@ function getRemainingClass(remaining, limit) {
 }
 
 async function checkRateLimit() {
-  const token = localStorage.getItem('github_token');
+  const token = localStorage.getItem('GITHUB_TOKEN');
   if (!token) {
     checkGithubAuth();
     return;
@@ -305,50 +303,74 @@ async function checkRateLimit() {
 
     const data = await response.json();
 
-    // GitHub's rate_limit endpoint returns a structured response
-    // We'll display the core rate limit and other resources
-    const resources = data.resources;
+    // Create table
+    const resultsContainer = document.createElement('div');
+    resultsContainer.className = 'results';
+
+    resultsContainer.innerHTML = `
+      <h2>GitHub API Rate Limits</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Resource</th>
+            <th>Limit</th>
+            <th>Used</th>
+            <th>Remaining</th>
+            <th>Resets At</th>
+            <th>Resets In</th>
+          </tr>
+        </thead>
+        <tbody id="tableBody">
+        </tbody>
+      </table>
+      <div class="timestamp">Last checked: ${new Date().toLocaleString()}</div>
+    `;
+
+    resultsDiv.appendChild(resultsContainer);
+    const tableBody = document.getElementById('tableBody');
+
+    // Track previous row's reset values for ditto marks
+    let prevResetsAt = null;
+    let prevResetsIn = null;
 
     // Display each resource type
+    const resources = data.resources;
     for (const [resourceType, resourceData] of Object.entries(resources)) {
-      const section = document.createElement('div');
-      section.className = 'section';
-
       const limit = resourceData.limit;
       const remaining = resourceData.remaining;
       const used = resourceData.used;
       const reset = resourceData.reset;
       const remainingClass = getRemainingClass(remaining, limit);
 
-      section.innerHTML = `
-        <h2>${resourceType.toUpperCase()} API</h2>
-        <div class="rate-limit-grid">
-          <div class="rate-limit-label">Limit:</div>
-          <div class="rate-limit-value">${limit.toLocaleString()}</div>
+      const resetsAt = formatTimestamp(reset);
+      const resetsIn = formatTimeRemaining(reset);
 
-          <div class="rate-limit-label">Used:</div>
-          <div class="rate-limit-value">${used.toLocaleString()}</div>
+      // Use ditto marks if values match previous row
+      const displayResetsAt = (resetsAt === prevResetsAt) ? '″' : resetsAt;
+      const displayResetsIn = (resetsIn === prevResetsIn) ? '″' : resetsIn;
 
-          <div class="rate-limit-label">Remaining:</div>
-          <div class="rate-limit-value ${remainingClass}">${remaining.toLocaleString()}</div>
-
-          <div class="rate-limit-label">Resets at:</div>
-          <div class="rate-limit-value">${formatTimestamp(reset)}</div>
-
-          <div class="rate-limit-label">Resets in:</div>
-          <div class="rate-limit-value">${formatTimeRemaining(reset)}</div>
-        </div>
-        <div class="timestamp">Last checked: ${new Date().toLocaleString()}</div>
+      const row = document.createElement('tr');
+      row.innerHTML = `
+        <td class="resource-name">${resourceType}</td>
+        <td class="number">${limit.toLocaleString()}</td>
+        <td class="number">${used.toLocaleString()}</td>
+        <td class="number ${remainingClass}">${remaining.toLocaleString()}</td>
+        <td class="${displayResetsAt === '″' ? 'ditto' : ''}">${displayResetsAt}</td>
+        <td class="${displayResetsIn === '″' ? 'ditto' : ''}">${displayResetsIn}</td>
       `;
 
-      resultsDiv.appendChild(section);
+      tableBody.appendChild(row);
+
+      // Update previous values
+      prevResetsAt = resetsAt;
+      prevResetsIn = resetsIn;
     }
 
   } catch (error) {
     console.error('Rate limit check failed:', error);
 
     if (error.message.includes('401') || error.message.includes('403')) {
-      localStorage.removeItem('github_token');
+      localStorage.removeItem('GITHUB_TOKEN');
       checkGithubAuth();
       resultsDiv.innerHTML = '<div class="error">Authentication failed. Please authenticate again.</div>';
     } else {

--- a/openai-audio-output.html
+++ b/openai-audio-output.html
@@ -216,7 +216,7 @@
         }
 
         function checkGithubAuth() {
-            const token = localStorage.getItem('github_token');
+            const token = localStorage.getItem('GITHUB_TOKEN');
             if (token) {
                 authLinkContainer.style.display = 'none';
                 saveGistBtn.style.display = 'inline-block';
@@ -228,7 +228,7 @@
 
         function startAuthPoll() {
             const pollInterval = setInterval(() => {
-                if (localStorage.getItem('github_token')) {
+                if (localStorage.getItem('GITHUB_TOKEN')) {
                     checkGithubAuth();
                     clearInterval(pollInterval);
                 }
@@ -241,7 +241,7 @@
         });
 
         async function createGist() {
-            const token = localStorage.getItem('github_token');
+            const token = localStorage.getItem('GITHUB_TOKEN');
             if (!token) {
                 checkGithubAuth();
                 return;
@@ -283,7 +283,7 @@
                 `;
             } catch (error) {
                 console.error('Gist creation failed:', error);
-                localStorage.removeItem('github_token');
+                localStorage.removeItem('GITHUB_TOKEN');
                 checkGithubAuth();
             } finally {
                 saveGistBtn.disabled = false;

--- a/terminal-to-html.html
+++ b/terminal-to-html.html
@@ -444,7 +444,7 @@ function escapeHtml(text) {
 }
 
 function checkGithubAuth() {
-  const token = localStorage.getItem('github_token');
+  const token = localStorage.getItem('GITHUB_TOKEN');
   const authLinkContainer = document.getElementById('authLinkContainer');
   const saveGistBtn = document.getElementById('saveGistBtn');
   const privateGistLabel = document.getElementById('privateGistLabel');
@@ -466,7 +466,7 @@ function checkGithubAuth() {
 
 function startAuthPoll() {
   const pollInterval = setInterval(() => {
-    if (localStorage.getItem('github_token')) {
+    if (localStorage.getItem('GITHUB_TOKEN')) {
       checkGithubAuth();
       clearInterval(pollInterval);
     }
@@ -474,7 +474,7 @@ function startAuthPoll() {
 }
 
 async function createGist(htmlContent) {
-  const token = localStorage.getItem('github_token');
+  const token = localStorage.getItem('GITHUB_TOKEN');
   if (!token) {
     checkGithubAuth();
     return;
@@ -541,7 +541,7 @@ async function createGist(htmlContent) {
 
   } catch (error) {
     console.error('Gist creation failed:', error);
-    localStorage.removeItem('github_token');
+    localStorage.removeItem('GITHUB_TOKEN');
     checkGithubAuth();
     gistLinks.innerHTML = '<div style="color: #f00;">Failed to create gist. Please try again.</div>';
   } finally {


### PR DESCRIPTION
- Redesigned github-ratelimit.html with clean table layout
  - Removed green-on-black terminal styling
  - Switched to modern GitHub-style design with professional colors
  - Implemented ditto marks (″) for repeated "resets at" and "resets in" values
  - Better mobile responsiveness

- Standardized GitHub token localStorage key to GITHUB_TOKEN across all tools:
  - github-ratelimit.html (changed from github_token)
  - github-issue.html (changed from githubToken)
  - terminal-to-html.html (changed from github_token)
  - openai-audio-output.html (changed from github_token)

All tools now use consistent GITHUB_TOKEN key for better maintainability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Prompt was:

> Redesign github-ratelimit to not use the green-on-black style. Have it show the results in a table, and if a row has the same values for resets at and resets in as the previous row it should show ditto marks instead.
> 
> Also take a look at any other tools that store a github token in localStorage and make sure that ALL of them use the same key for it, which should be GITHUB_TOKEN (including this tool)