### PR TITLE
Fix: Add missing CSS styles to wrapInHtmlDocument output

### DIFF
--- a/terminal-to-html.html
+++ b/terminal-to-html.html
@@ -450,8 +450,22 @@ function wrapInHtmlDocument(content) {
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Terminal Output</title>
+  <style>
+    body {
+      background: black;
+      color: #0f0;
+      font-family: 'Courier New', Courier, monospace;
+      margin: 0;
+      padding: 15px;
+      line-height: 1.6;
+    }
+    pre {
+      color: #0f0;
+      font-family: 'Courier New', Courier, monospace;
+    }
+  </style>
 </head>
-<body style="background: black; margin: 0; padding: 0;">
+<body>
 ${content}
 </body>
 </html>`;


### PR DESCRIPTION
## Summary
The `wrapInHtmlDocument` function was creating a complete HTML document with a black background but no text styling. This resulted in black text on a black background when the output is viewed as a standalone HTML file, making it unreadable.

## Changes
- Added a `<style>` tag to the generated HTML document
- Set text color to green (#0f0) for both `body` and `pre` elements
- Added proper font-family, line-height, and padding to match the tool's styling
- Replaced inline styles with a proper stylesheet for better maintainability

## Testing
The fix ensures that when users copy the generated HTML and view it as a standalone file, the terminal output is displayed with visible green text on a black background, matching the tool's appearance in the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)