### PR TITLE
Add URL query string handling to bluesky-thread.html

### DIFF
--- a/bluesky-thread.html
+++ b/bluesky-thread.html
@@ -192,6 +192,10 @@
         container.innerHTML = '';
         copyContainer.style.display = 'none';
         lastThread = null;
+        // Update URL with the submitted post URL
+        const newUrl = new URL(window.location);
+        newUrl.searchParams.set('url', postUrl.value.trim());
+        history.replaceState(null, '', newUrl);
         try {
           const url = new URL(postUrl.value.trim());
           if (url.hostname !== 'bsky.app') throw new Error('URL must be from bsky.app');
@@ -247,6 +251,14 @@
           container.textContent = 'Error: ' + err.message;
         }
       });
+
+      // Check for ?url= query parameter on page load
+      const params = new URLSearchParams(window.location.search);
+      const urlParam = params.get('url');
+      if (urlParam) {
+        postUrl.value = urlParam;
+        form.requestSubmit();
+      }
     })();
   </script>
 </body>


### PR DESCRIPTION
- When form is submitted, update page URL to include ?url=... parameter
- On page load, check for ?url= query parameter and auto-populate/submit form
- Enables sharing direct links to specific Bluesky threads

Claude code for web prompt:

> Modify bluesky-thread.html so when the form is submitted it updates the page URL to include ?url=… and when the page loads of that query string is present it populates the form field and submits the form