### PR TITLE
Add URL parameter for view mode in Bluesky thread viewer

### DIFF
--- a/bluesky-thread.html
+++ b/bluesky-thread.html
@@ -330,6 +330,10 @@
             currentView = view;
             viewTabs.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
             e.target.classList.add('active');
+            // Update URL with current view
+            const newUrl = new URL(window.location);
+            newUrl.searchParams.set('view', view);
+            history.replaceState(null, '', newUrl);
             renderCurrentView();
           }
         }
@@ -368,14 +372,10 @@
         viewTabs.style.display = 'none';
         lastThread = null;
         allPosts = [];
-        currentView = 'thread';
-        // Reset tabs to default
-        viewTabs.querySelectorAll('.tab').forEach(t => {
-          t.classList.toggle('active', t.dataset.view === 'thread');
-        });
-        // Update URL with the submitted post URL
+        // Update URL with the submitted post URL and current view
         const newUrl = new URL(window.location);
         newUrl.searchParams.set('url', postUrl.value.trim());
+        newUrl.searchParams.set('view', currentView);
         history.replaceState(null, '', newUrl);
         try {
           const url = new URL(postUrl.value.trim());
@@ -413,9 +413,17 @@
         }
       });
 
-      // Check for ?url= query parameter on page load
+      // Check for query parameters on page load
       const params = new URLSearchParams(window.location.search);
       const urlParam = params.get('url');
+      const viewParam = params.get('view');
+      // Initialize view from URL parameter if valid
+      if (viewParam === 'thread' || viewParam === 'recent') {
+        currentView = viewParam;
+        viewTabs.querySelectorAll('.tab').forEach(t => {
+          t.classList.toggle('active', t.dataset.view === viewParam);
+        });
+      }
       if (urlParam) {
         postUrl.value = urlParam;
         form.requestSubmit();


### PR DESCRIPTION
The view mode (thread/recent) is now persisted in the URL as a `view`
parameter. This allows users to refresh the page and maintain their
selected view mode. Changes:
- Tab clicks update URL with current view
- Form submission preserves view mode in URL
- Page load reads view parameter to restore state

----

> Bluesky thread viewer should use a URL parameter to record if the app is in thread view or most recent view, so hitting refresh works to see latest posts