### PR TITLE
Set document.title to reflect focused post in quote finder

### DIFF
--- a/bluesky-quote-finder.html
+++ b/bluesky-quote-finder.html
@@ -458,11 +458,10 @@
           renderQuotes();
 
           // Update document title to reflect the focused post
-          const authorName = post.author.displayName || post.author.handle;
           const truncatedText = post.record.text.length > 50
             ? post.record.text.substring(0, 50) + '…'
             : post.record.text;
-          document.title = `Quotes of "${truncatedText}" by ${authorName}`;
+          document.title = `Quotes of @${post.author.handle}: "${truncatedText}"`;
 
         } catch (err) {
           console.error(err);


### PR DESCRIPTION
After loading the post data, updates the page title to show
a truncated version of the post text and the author name,
making it easier to identify tabs when multiple are open.

----

> Modify the Bluesky quote tweet tool to set document.title to reflect the focused post once it has loaded the data