### PR TITLE
Add URL parameter support to cors-fetch

### DIFF
--- a/cors-fetch.html
+++ b/cors-fetch.html
@@ -459,15 +459,45 @@
       }
     }
 
+    // Update browser URL with the fetch URL parameter
+    function updatePageUrl(fetchUrl) {
+      if (fetchUrl) {
+        const newUrl = new URL(window.location.href);
+        newUrl.searchParams.set("url", fetchUrl);
+        history.replaceState(null, "", newUrl.toString());
+      }
+    }
+
+    // Read URL parameter on page load
+    function getUrlParam() {
+      const params = new URLSearchParams(window.location.search);
+      return params.get("url");
+    }
+
     fetchBtn.addEventListener("click", () => {
+      const url = normalizeUrl(urlInput.value);
+      if (url) {
+        updatePageUrl(url);
+      }
       doFetch();
     });
 
     urlInput.addEventListener("keydown", (e) => {
       if (e.key === "Enter") {
+        const url = normalizeUrl(urlInput.value);
+        if (url) {
+          updatePageUrl(url);
+        }
         doFetch();
       }
     });
+
+    // On page load, check for URL parameter and auto-fetch
+    const initialUrl = getUrlParam();
+    if (initialUrl) {
+      urlInput.value = initialUrl;
+      doFetch();
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
- Read ?url=... parameter on page load and auto-fetch
- Update page URL with ?url=... when making fetch requests
- Allows sharing direct links to test specific URLs

----

> Make cors-fetch work by updating the page URL to include ?url=… and have it fetch that URL when the page loads if it has been provided