### PR TITLE
Add model selection and customizable system prompt to omit-needless-words

### DIFF
--- a/omit-needless-words.html
+++ b/omit-needless-words.html
@@ -604,6 +604,18 @@ function updatePromptBanner() {
     // No custom prompt saved
     customPromptBanner.classList.add('hidden');
   }
+
+  // Update save button text
+  updateSaveButtonText();
+}
+
+function updateSaveButtonText() {
+  const savedCustomPrompt = localStorage.getItem('omit-needless-words-custom-prompt');
+  if (savedCustomPrompt) {
+    savePromptBtn.textContent = 'Update custom prompt';
+  } else {
+    savePromptBtn.textContent = 'Save as custom prompt';
+  }
 }
 
 function getCurrentPrompt() {
@@ -616,9 +628,16 @@ function getCurrentPrompt() {
 savePromptBtn.addEventListener('click', () => {
   const promptText = systemPromptTextarea.value.trim();
   if (promptText) {
-    localStorage.setItem('omit-needless-words-custom-prompt', promptText);
-    localStorage.setItem('omit-needless-words-use-custom', 'true');
-    useCustomPrompt = true;
+    // If saving the default prompt, clear the custom prompt instead
+    if (promptText === DEFAULT_PROMPT.trim()) {
+      localStorage.removeItem('omit-needless-words-custom-prompt');
+      localStorage.setItem('omit-needless-words-use-custom', 'false');
+      useCustomPrompt = false;
+    } else {
+      localStorage.setItem('omit-needless-words-custom-prompt', promptText);
+      localStorage.setItem('omit-needless-words-use-custom', 'true');
+      useCustomPrompt = true;
+    }
     updatePromptBanner();
   }
 });


### PR DESCRIPTION
- Add model selector dropdown defaulting to Haiku 4.5, with options for
  Sonnet 4.5 and Opus 4.5
- Add collapsible system prompt editor in a details/summary element
- Save custom prompts to localStorage with buttons to save and reset
- Show visible banner when using a custom prompt with toggle button
  to switch back to default

----

> Modify omit needless words to include a select topics the model - default to haiku (find the model string in the commit history) but also allows opus 4.5 or sonnet 4.5
Make the system prompt editable - put that in a details/summary that defaults to closed
Save custom prompts in local storage - if one is set show a visible note that it is running with a custom prompt and provide a button to toggle between default and custom and back again