### PR TITLE
Hide repeated usernames in hide-other-replies mode

### DIFF
--- a/bluesky-thread.html
+++ b/bluesky-thread.html
@@ -369,6 +369,10 @@
     #threadContainer.hide-other-replies .post:not(.depth-1.root-author-post) {
       display: none;
     }
+    /* Hide repeated usernames in hide-other-replies mode (but keep date/links visible) */
+    #threadContainer.hide-other-replies .post.depth-1.root-author-post.author-continuation .author {
+      display: none;
+    }
     @media (max-width: 600px) {
       .post { padding-left: 1em; }
     }


### PR DESCRIPTION
When toggling to "hide other replies" mode, the username is now hidden
on continuation posts (those after the first), while keeping the date
stamp and "View on Bluesky" link visible. Usernames reappear when
toggling back out of hide mode.

----

> For bluesky-thread in “hide other replies” mode hide the repeated username after the first displayed post but keep the date stamp and view on Bluesky links
Make those visible again when toggling back out of that mode