### PR TITLE
Improve mobile design for jina-reader

### DIFF
--- a/jina-reader.html
+++ b/jina-reader.html
@@ -15,47 +15,68 @@
         }
         h1 {
             font-size: 24px;
+            margin-bottom: 16px;
+        }
+        h1 + p {
             margin-bottom: 20px;
+            color: #666;
         }
-        #url-input, #format-select, #submit-btn, #markdown-raw, #copy-btn, #prompt-textarea, #run-prompt-btn {
+        #url-form {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+        #url-input, #format-select, #submit-btn, #markdown-raw, .copy-btn, #prompt-textarea, #run-prompt-btn {
             font-size: 16px;
-            padding: 5px;
-            margin-bottom: 10px;
+            padding: 10px 12px;
             box-sizing: border-box;
+            border-radius: 6px;
         }
-        #url-input {
-            width: 50%;
+        #url-input, #format-select {
+            width: 100%;
+            border: 1px solid #ccc;
+            background: #fff;
         }
-        #format-select {
-            width: 20%;
+        #url-input:focus, #format-select:focus, #prompt-textarea:focus {
+            outline: none;
+            border-color: #4CAF50;
+            box-shadow: 0 0 0 2px rgba(76, 175, 80, 0.2);
         }
         #submit-btn, .copy-btn, #run-prompt-btn {
             background-color: #4CAF50;
             color: white;
-            border: 2px solid #4CAF50;
+            border: none;
             cursor: pointer;
+            font-weight: 500;
         }
         #submit-btn:hover, .copy-btn:hover, #run-prompt-btn:hover {
             background-color: #45a049;
+        }
+        #submit-btn:active, .copy-btn:active, #run-prompt-btn:active {
+            transform: scale(0.98);
         }
         #markdown-raw, #prompt-textarea {
             width: 100%;
             height: 200px;
             margin-top: 20px;
             resize: vertical;
+            border: 1px solid #ccc;
         }
         #prompt-textarea {
             height: 100px;
+            margin-top: 0;
         }
         #markdown-rendered {
             margin-top: 20px;
             border: 1px solid #ccc;
             padding: 10px;
             overflow-wrap: break-word;
+            border-radius: 6px;
         }
         #loading, #prompt-loading {
             display: none;
             margin-top: 20px;
+            color: #666;
         }
         #result, #prompt-result {
             display: none;
@@ -84,22 +105,23 @@
             height: 500px;
             box-sizing: border-box;
             border: 1px solid #ccc;
+            border-radius: 6px;
         }
-        @media (min-width: 768px) {
+        @media (min-width: 540px) {
+            #url-form {
+                flex-direction: row;
+                flex-wrap: wrap;
+                align-items: center;
+            }
             #url-input {
-                width: 50%;
-                display: inline-block;
+                flex: 1;
+                min-width: 200px;
             }
             #format-select {
-                width: 20%;
-                display: inline-block;
-                margin-left: 2%;
+                width: auto;
+                min-width: 140px;
             }
             #submit-btn {
-                display: inline-block;
-                margin-left: 2%;
-            }
-            #copy-btn {
                 width: auto;
             }
         }
@@ -121,7 +143,7 @@
     <div id="loading">Loading...</div>
     <div id="result">
         <textarea id="markdown-raw" readonly></textarea>
-        <button id="copy-btn">Copy to clipboard</button>
+        <button id="copy-btn" class="copy-btn">Copy to clipboard</button>
         <iframe id="markdown-rendered" sandbox></iframe>
     </div>
 


### PR DESCRIPTION
- Stack form elements vertically on mobile with full-width inputs
- Use flexbox layout with 12px gap between elements
- Increase touch target size with larger padding (10px 12px)
- Add subtle border-radius (6px) to inputs, buttons, and iframe
- Add focus states with green accent color
- Switch to row layout on screens >= 540px
- Add subtle active state animation on buttons

----

> Improve the design of jina-reader - keep it minimal but have it look nicer in mobile the select box gets a bit cramped right now