### PR TITLE
Move date fields to advanced search and hide UI until signed in

### DIFF
--- a/bluesky-search.html
+++ b/bluesky-search.html
@@ -113,18 +113,8 @@
     input[type="text"] {
       flex: 1;
     }
-    .date-filters {
-      display: flex;
-      gap: 1em;
-      flex-wrap: wrap;
-      align-items: center;
-    }
-    .date-filters label {
-      display: flex;
-      gap: 0.5em;
-      align-items: center;
-      font-size: 0.9rem;
-      color: #666;
+    .controls.hidden {
+      display: none;
     }
     .advanced-search {
       margin-top: 0.5em;
@@ -393,7 +383,6 @@
       .post { padding-left: 1em; }
       .tab { padding: 0.5em 0.75em; font-size: 0.9rem; }
       .search-row { flex-direction: column; }
-      .date-filters { flex-direction: column; align-items: flex-start; }
     }
   </style>
 </head>
@@ -416,25 +405,25 @@
       </div>
       <div class="auth-status" id="authStatus">Not logged in. <a href="https://bsky.app/settings/app-passwords" target="_blank">Create an app password</a></div>
     </details>
-    <div class="controls">
+    <div class="controls hidden" id="controls">
       <form id="searchForm">
         <div class="search-row">
           <input type="text" id="searchQuery" placeholder="Enter search query..." required />
           <button type="submit">Search</button>
         </div>
-        <div class="date-filters">
-          <label>
-            Since:
-            <input type="date" id="sinceDate" />
-          </label>
-          <label>
-            Until:
-            <input type="date" id="untilDate" />
-          </label>
-        </div>
         <details class="advanced-search">
           <summary>Advanced Search Options</summary>
           <div class="advanced-fields">
+            <label>
+              Since
+              <input type="date" id="sinceDate" />
+              <span class="field-hint">Posts from this date onwards</span>
+            </label>
+            <label>
+              Until
+              <input type="date" id="untilDate" />
+              <span class="field-hint">Posts up to this date</span>
+            </label>
             <label>
               Author
               <input type="text" id="authorFilter" placeholder="handle or DID" />
@@ -568,6 +557,7 @@
           authStatus.innerHTML = `Logged in as <strong>@${data.handle}</strong> <button class="logout-btn" id="logoutBtn">Logout</button>`;
           authStatus.className = 'auth-status logged-in';
           authSection.open = false;
+          document.getElementById('controls').classList.remove('hidden');
 
           // Add logout handler
           document.getElementById('logoutBtn').addEventListener('click', logout);
@@ -591,6 +581,7 @@
         authStatus.innerHTML = 'Not logged in. <a href="https://bsky.app/settings/app-passwords" target="_blank">Create an app password</a>';
         authStatus.className = 'auth-status';
         authSection.open = true;
+        document.getElementById('controls').classList.add('hidden');
       }
 
       // Login button handler
@@ -1215,7 +1206,7 @@
       }
 
       // Open advanced search if any advanced filters are set
-      const hasAdvancedFilters = authorParam || mentionsParam || langParam || domainParam || urlParam || tagsParam;
+      const hasAdvancedFilters = sinceParam || untilParam || authorParam || mentionsParam || langParam || domainParam || urlParam || tagsParam;
       if (hasAdvancedFilters) {
         document.querySelector('.advanced-search').open = true;
       }


### PR DESCRIPTION
- Move Since/Until date filters into the Advanced Search Options section
- Hide search form until user has successfully logged in
- Show controls when login succeeds, hide on logout
- Include date params in URL restore logic for advanced filters

----

> Move the date fields into the advanced search bit on the Bluesky search tool. Do not show the search UI until the user has signed in