### PR TITLE
Add ?issue= URL parameter support for auto-fetching

### DIFF
--- a/github-issue-to-markdown.html
+++ b/github-issue-to-markdown.html
@@ -525,6 +525,31 @@ copyButton.addEventListener('click', () => {
   })
 })
 
+// Update URL with ?issue= parameter
+function updateUrlParam(issueUrl) {
+  const url = new URL(window.location)
+  if (issueUrl) {
+    url.searchParams.set('issue', issueUrl)
+  } else {
+    url.searchParams.delete('issue')
+  }
+  history.replaceState(null, '', url)
+}
+
+// Check for ?issue= parameter on page load and auto-fetch
+const params = new URLSearchParams(window.location.search)
+const issueParam = params.get('issue')
+if (issueParam) {
+  urlInput.value = issueParam
+  handleConvert()
+}
+
+// Update URL when input changes
+urlInput.addEventListener('input', () => {
+  const issueUrl = urlInput.value.trim()
+  updateUrlParam(issueUrl)
+})
+
 </script>
 </body>
 </html>


### PR DESCRIPTION
- Persist the issue URL in the ?issue= query parameter when typing
- Automatically fetch and convert issues when the page loads with ?issue= populated
- Enables sharing direct links to converted issues

----

> github-issue-to-markdown make it persist the issue URL in the ?issue= parameter and fetch an issue automatically if that is populated when the page loads