### PR TITLE
Fix mobile layout for pypi-changelog diff view

### DIFF
--- a/pypi-changelog.html
+++ b/pypi-changelog.html
@@ -170,8 +170,14 @@ p code {
   position: relative;
 }
 .d2h-code-line-ctn {
-  word-break: break-all;
-  white-space: pre-wrap;
+  white-space: pre;
+}
+/* Mobile-friendly diff display - allow horizontal scroll instead of breaking */
+.d2h-file-wrapper {
+  overflow-x: auto;
+}
+.d2h-diff-table {
+  min-width: 600px;
 }
 @media (min-width: 500px) {
   body {


### PR DESCRIPTION
Remove word-break: break-all which caused text to display vertically
(one character per line) on mobile. Instead, allow horizontal scrolling
for the diff table with a minimum width to prevent squishing.

----

> On mobile https://tools.simonwillison.net/pypi-changelog?package=LLM&compare=0.27…0.27.1 looked  like this, unreadable
>
> <img width="660" height="1434" alt="IMG_0944" src="https://github.com/user-attachments/assets/455e2359-678e-4dfc-8e9c-8db73534292d" />
