### PR TITLE
Enhance CORS-fetch with HTTP methods, request body options, and URL state

### DIFF
--- a/cors-fetch.html
+++ b/cors-fetch.html
@@ -1328,6 +1328,34 @@ curl -X POST 'https://api.example.com/data' \
       };
     }
 
+    function updateDocumentTitle() {
+      const method = methodSelect.value;
+      const url = urlInput.value.trim();
+
+      if (!url) {
+        document.title = "CORS Fetch Tester";
+        return;
+      }
+
+      // Extract hostname/path from URL for a cleaner title
+      let urlPart = url;
+      try {
+        const parsed = new URL(url.startsWith("http") ? url : "https://" + url);
+        urlPart = parsed.hostname + (parsed.pathname !== "/" ? parsed.pathname : "");
+        // Truncate if too long
+        if (urlPart.length > 40) {
+          urlPart = urlPart.substring(0, 37) + "...";
+        }
+      } catch {
+        // If URL parsing fails, just use the raw value (truncated)
+        if (urlPart.length > 40) {
+          urlPart = urlPart.substring(0, 37) + "...";
+        }
+      }
+
+      document.title = `${method} ${urlPart} - CORS Fetch`;
+    }
+
     function updateFragmentFromState() {
       const state = getStateForFragment();
       const fragment = encodeStateToFragment(state);
@@ -1336,6 +1364,7 @@ curl -X POST 'https://api.example.com/data' \
       } else {
         history.replaceState(null, "", window.location.pathname + window.location.search);
       }
+      updateDocumentTitle();
     }
 
     function loadStateFromFragment() {
@@ -1370,6 +1399,7 @@ curl -X POST 'https://api.example.com/data' \
         }
         renderHeaderPairs();
         updateHeadersCount();
+        updateDocumentTitle();
 
         return true;
       } catch (e) {
@@ -1383,6 +1413,7 @@ curl -X POST 'https://api.example.com/data' \
       const urlParam = params.get("url");
       if (urlParam) {
         urlInput.value = urlParam;
+        updateDocumentTitle();
         return true;
       }
       return false;


### PR DESCRIPTION
- Add HTTP method selector (GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS)
- Add request body options: None, JSON, and Form (URL-encoded)
- Add key/value pair editor for form-encoded bodies
- Implement #fragment URL scheme to persist form state
- Load state from URL on page load without auto-executing
- Make all form elements mobile-friendly (16px font to prevent iOS zoom)
- Increase touch targets to 44px minimum height
- Support legacy ?url= query parameter

----

> Improve CORS-fetch:
>
> - ensure it is mobile friendly in that the font size of all the elements is such that the browser doesn't zoom when you select them
> - add other HTTP verbs
> - add an option to send a form body - have both JSON and form encoded POST options with a key/value pair editor for the form one
> - update a #fragment URL scheme to reflect the form state
> - on load set the form state to that stuff in the URL - but do not execute the call until the button is pressed