### PR TITLE
Add justhtml.html - Pyodide playground for HTML5 parsing

### DIFF
--- a/justhtml.html
+++ b/justhtml.html
@@ -569,14 +569,14 @@ def get_tree_structure(html_str, indent=0):
 
         name = getattr(node, 'name', None)
         if name:
-            attrs = getattr(node, 'attrs', {})
+            attrs = getattr(node, 'attrs', None) or {}
             if attrs:
                 attr_str = " ".join(f'{k}="{v}"' for k, v in attrs.items())
                 lines.append(f"{prefix}<{name} {attr_str}>")
             else:
                 lines.append(f"{prefix}<{name}>")
 
-            children = getattr(node, 'children', [])
+            children = getattr(node, 'children', None) or []
             for child in children:
                 lines.extend(format_node(child, depth + 1))
         else:
@@ -591,7 +591,8 @@ def get_tree_structure(html_str, indent=0):
         return lines
 
     lines = []
-    for child in doc.root.children:
+    root_children = getattr(doc.root, 'children', None) or []
+    for child in root_children:
         lines.extend(format_node(child, 0))
     return "\\n".join(lines)
 


### PR DESCRIPTION
A mobile-friendly playground for the justhtml Python library that:
- Installs justhtml from PyPI using micropip
- Supports pasting HTML or fetching from CORS-enabled URLs
- Includes multiple playground modes:
  - CSS Selector query with example selectors
  - Pretty print HTML
  - Tree structure visualization
  - Stream events display
- No React dependencies, pure vanilla JS

----
### Claude Code for web prompt:

> Clone https://github.com/EmilStenstrom/justhtml into /tmp
>
> Examine existing tools in this repo that use Pyodide
>
> Build justhtml.html as a playground for trying out this new HTML Python parsing library 
>
> It should install the library from PyPI using micropip
>
> It should have an option to paste in HTML, and another option to add a URL to something that can be fetched via CORS
>
> Include various playground options, including one for trying out the CSS selector implementation and one for pretty printing HTML
> 
> Mobile friendly, no react