### PR TITLE
Add clipboard-backup.html - multi-format clipboard backup tool

### DIFF
--- a/clipboard-backup.html
+++ b/clipboard-backup.html
@@ -464,8 +464,8 @@
             URL.revokeObjectURL(url);
         }
 
-        // Clipboard API only supports these types
-        const SUPPORTED_CLIPBOARD_TYPES = ['text/plain', 'text/html', 'image/png', 'image/jpeg', 'image/gif', 'image/webp'];
+        // Clipboard API only supports these types (text/uri-list works via text/plain fallback)
+        const SUPPORTED_CLIPBOARD_TYPES = ['text/plain', 'text/html', 'text/uri-list', 'image/png', 'image/jpeg', 'image/gif', 'image/webp'];
 
         function hasUnsupportedFormats(formats) {
             return Object.keys(formats).some(type =>


### PR DESCRIPTION
A tool that preserves clipboard content across all formats (plain text,
HTML, RTF, images) and allows restoring it later. Features:
- Paste to save clipboard content with all available formats
- IndexedDB persistence for storing multiple backups
- Preview tabs for viewing different formats
- Copy button to restore full multi-format clipboard
- Delete individual backups or clear all

----

> Build clipboard-backup.html - it’s a tool you can paste into and it exactly preserves everything in your clipboard across all formats (plain txt and rtf and so on) and gives you a “copy” button to copy that back to the clipboard again in the future
>
> It can be pasted into multiple times, each paste is persisted to indexedDB and shows a copy button along with a scrollable preview of what’s been stored - there is a delete button as well