### PR TITLE
Fix inconsistent font sizes in diff view

### DIFF
--- a/pypi-changelog.html
+++ b/pypi-changelog.html
@@ -174,10 +174,16 @@ p code {
   white-space: pre;
 }
 /* Normalize font sizes across diff elements */
+.diff-content .d2h-diff-table,
+.diff-content .d2h-diff-table td,
 .diff-content .d2h-code-line,
 .diff-content .d2h-code-side-line,
 .diff-content .d2h-code-line-ctn,
+.diff-content .d2h-code-line-prefix,
 .diff-content .d2h-code-linenumber,
+.diff-content .d2h-code-side-linenumber,
+.diff-content .line-num1,
+.diff-content .line-num2,
 .diff-content .d2h-file-header,
 .diff-content .d2h-file-stats,
 .diff-content .d2h-info {


### PR DESCRIPTION
Set explicit font-size on .diff-content container (13px) and ensure
diff2html elements inherit consistent sizing by overriding d2h-code-line,
d2h-code-side-line, d2h-code-line-ctn, and d2h-code-linenumber.

----

> pypi-changelog?package=justhtml&compare=0.9.0…0.10.0 has inconsistent font sizes in the text diff view
>
> ![IMG_1034](https://github.com/user-attachments/assets/87fda0ba-3d5b-4165-8caf-2da6c81a9482)
