### PR TITLE
Update page design to match til.simonwillison.net

### DIFF
--- a/build_by_month.py
+++ b/build_by_month.py
@@ -167,9 +167,10 @@ def build_by_month() -> None:
             color: white;
         }
         nav p {
-            display: block;
+            display: flex;
+            justify-content: space-between;
             margin: 0;
-            padding: 4px 0px 4px 2em;
+            padding: 4px 2em;
         }
         nav a:link,
         nav a:visited,
@@ -213,14 +214,14 @@ def build_by_month() -> None:
                 padding: 0em 1em;
             }
             nav p {
-                padding: 4px 0px 4px 1em;
+                padding: 4px 1em;
             }
         }
     </style>
 </head>
 <body>
 <nav>
-    <p><a href="/">Simon Willison's Tools</a></p>
+    <p><a href="/">Simon Willison's Tools</a> <a href="https://simonwillison.net/">My blog</a></p>
 </nav>
 <section class="body">
     <h1>Tools by month</h1>

--- a/build_colophon.py
+++ b/build_colophon.py
@@ -105,9 +105,10 @@ def build_colophon():
             color: white;
         }
         nav p {
-            display: block;
+            display: flex;
+            justify-content: space-between;
             margin: 0;
-            padding: 4px 0px 4px 2em;
+            padding: 4px 2em;
         }
         nav a:link,
         nav a:visited,
@@ -215,7 +216,7 @@ def build_colophon():
                 padding: 0em 1em;
             }
             nav p {
-                padding: 4px 0px 4px 1em;
+                padding: 4px 1em;
             }
             .commit {
                 padding: 0.75rem;
@@ -225,7 +226,7 @@ def build_colophon():
 </head>
 <body>
 <nav>
-    <p><a href="/">Simon Willison's Tools</a></p>
+    <p><a href="/">Simon Willison's Tools</a> <a href="https://simonwillison.net/">My blog</a></p>
 </nav>
 <section class="body">
     <h1>tools.simonwillison.net colophon</h1>

--- a/build_index.py
+++ b/build_index.py
@@ -218,9 +218,10 @@ def build_index() -> None:
             color: white;
         }}
         nav p {{
-            display: block;
+            display: flex;
+            justify-content: space-between;
             margin: 0;
-            padding: 4px 0px 4px 2em;
+            padding: 4px 2em;
         }}
         nav a:link,
         nav a:visited,
@@ -239,7 +240,7 @@ def build_index() -> None:
                 padding: 0em 1em;
             }}
             nav p {{
-                padding: 4px 0px 4px 1em;
+                padding: 4px 1em;
             }}
         }}
         .recent-container {{
@@ -275,7 +276,7 @@ def build_index() -> None:
 </head>
 <body>
 <nav>
-    <p><a href="/">Simon Willison's Tools</a></p>
+    <p><a href="/">Simon Willison's Tools</a> <a href="https://simonwillison.net/">My blog</a></p>
 </nav>
 <section class="body">
 {body_html}


### PR DESCRIPTION
- Add purple gradient navigation bar at the top
- Use Georgia serif font for h1 headings
- Use Helvetica Neue for body text
- Wrap content in section.body with max-width 800px
- Remove border-bottom from headings for cleaner look
- Add responsive styles for mobile
- Use purple accent color for commit borders and blockquotes

----

> Update the visual design of the / and /colophon and /by-month pages (all built by scripts) to better match the design of https://til.simonwillison.net/ - you can clone that as simonw/til into /tmp to see its code