### PR TITLE
Make empty state clickable to add photos

### DIFF
--- a/image-print.html
+++ b/image-print.html
@@ -181,6 +181,12 @@ select:focus, input:focus {
   color: #999;
   cursor: pointer;
   transition: background 0.2s;
+  grid-column: 1 / -1;
+  grid-row: 1 / -1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 }
 
 .empty-state:hover {


### PR DESCRIPTION
The empty state in the image-print tool now opens the file picker
when clicked, providing a more intuitive way to add photos on mobile
where the file input may not be immediately visible

----

> Fix this
>
> ![IMG_1217](https://github.com/user-attachments/assets/0e90cc26-6e8e-4d21-a8a3-da6ab4732598)
