### PR TITLE
Add meta tags to exclude recipe timer from search

### DIFF
--- a/blackened-cauliflower-and-turkish-style-stew.html
+++ b/blackened-cauliflower-and-turkish-style-stew.html
@@ -4,6 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+  <meta name="robots" content="noindex, nofollow">
   <title>Dual Recipe Cooking Timer</title>
   <style>
     * {


### PR DESCRIPTION
> Add meta tags to the dual recipe cooking timer to exclude it from search

Refs: https://fedi.simonwillison.net/@simon/115769975249259060