### PR TITLE
Add serving time input to cooking timer

### DIFF
--- a/cooking-timer.html
+++ b/cooking-timer.html
@@ -443,6 +443,23 @@
       border-color: #fff;
     }
 
+    .serving-time-set {
+      background: linear-gradient(135deg, #00b894 0%, #00cec9 100%);
+      border: none;
+      color: #fff;
+      padding: 8px 16px;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 0.9rem;
+      font-weight: 600;
+      transition: transform 0.2s, box-shadow 0.2s;
+    }
+
+    .serving-time-set:hover {
+      transform: scale(1.05);
+      box-shadow: 0 2px 10px rgba(0, 184, 148, 0.3);
+    }
+
     .serving-time-cancel {
       background: transparent;
       border: none;
@@ -752,7 +769,8 @@
         <button class="serving-time-btn" id="servingTimeBtn" onclick="showServingTimeInput()">Set Serving Time</button>
         <div class="serving-time-input-wrapper hidden" id="servingTimeInputWrapper">
           <label for="servingTimeInput">Serve at:</label>
-          <input type="time" id="servingTimeInput" onchange="onServingTimeSelected()">
+          <input type="time" id="servingTimeInput">
+          <button class="serving-time-set" onclick="onServingTimeSelected()">Set</button>
           <button class="serving-time-cancel" onclick="hideServingTimeInput()">×</button>
         </div>
       </div>


### PR DESCRIPTION
> Modify cooking-timer.html to add a new feature: set desired serving time. This feature is available when the Start Cooking visible is shown. Clicking it brings up a input type=time that lets the user set the desired serving time for the meal. Once a serving time has been selected treat it as if the start cooking button has been clicked, update all times on the page to the time they need to be done in order to meet that serving time, then run the timer as normal.

Allows users to set a desired serving time instead of starting immediately. The timer calculates when to start each step to meet the target time, showing a countdown until cooking begins and displaying correct clock times in the timeline.

https://gistpreview.github.io/?fc5236c585ebfc7dd7748e9173ed6ac2/index.html