### PR TITLE
Add copy HTML newsletter to clipboard button

### DIFF
--- a/blog-to-newsletter.html
+++ b/blog-to-newsletter.html
@@ -339,6 +339,7 @@
 
   <div class="buttons">
     <button class="primary-btn" id="copyRichText">Copy rich text newsletter to clipboard</button>
+    <button class="primary-btn" id="copyHtml">Copy HTML newsletter to clipboard</button>
     <button class="secondary-btn" id="copyLinksOnly">Copy just the links/quotes/TILs</button>
   </div>
 
@@ -1067,6 +1068,16 @@ order by
 
       document.getElementById('copyRichText').addEventListener('click', () => {
         copyRichText(newsletterHTML);
+      });
+
+      document.getElementById('copyHtml').addEventListener('click', async () => {
+        try {
+          await navigator.clipboard.writeText(newsletterHTML);
+          showStatus('HTML copied to clipboard!', 'success');
+          setTimeout(hideStatus, 2000);
+        } catch (e) {
+          showStatus('Failed to copy: ' + e.message, 'error');
+        }
       });
 
       document.getElementById('copyLinksOnly').addEventListener('click', () => {


### PR DESCRIPTION
> Modify blog-to-newsletter and add a “Copy HTML newsletter to clipboard” button

Adds a new button next to the existing rich text copy button that copies
the raw HTML source of the newsletter to the clipboard, useful for pasting
into email HTML editors or other tools that need the markup directly.