### PR TITLE
Add line numbers and permalink anchors to files

### DIFF
--- a/zip-wheel-explorer.html
+++ b/zip-wheel-explorer.html
@@ -227,11 +227,12 @@ function formatContentWithLineNumbers(content, filename) {
     return html;
 }
 
-function highlightLine(lineNum) {
+function highlightLine(filename, lineNum) {
     // Remove any existing highlight
     document.querySelectorAll('.line-row.highlighted').forEach(el => el.classList.remove('highlighted'));
     // Find and highlight the specified line
-    const row = document.querySelector(`.line-row:nth-child(${lineNum})`);
+    const rowId = `${encodeURIComponent(filename)}--L${lineNum}`;
+    const row = document.getElementById(rowId);
     if (row) {
         row.classList.add('highlighted');
         row.scrollIntoView({ behavior: 'smooth', block: 'center' });
@@ -275,7 +276,7 @@ function selectFile(filename, lineNum, updateHash = true) {
             const ln = parseInt(a.dataset.line, 10);
             const input = document.getElementById('urlInput').value.trim();
             updateUrl(input, encodeFragment(file.name, ln));
-            highlightLine(ln);
+            highlightLine(file.name, ln);
         };
     });
 
@@ -290,7 +291,7 @@ function selectFile(filename, lineNum, updateHash = true) {
 
     // Highlight line if specified
     if (lineNum !== null) {
-        setTimeout(() => highlightLine(lineNum), 100);
+        setTimeout(() => highlightLine(filename, lineNum), 100);
     }
 }
 


### PR DESCRIPTION
> Upgrade zip-wheel-explorer so it shows line numbers for exery displayed text file, and each line number is a permalink which you can click that then adds `#filename--L33` or similar to the URL, and when the page loads if that fragment is present the specified file is shown and the line number is jumped to and the line is highlighted.
> 
> Also make each filename have a # icon next to it which targets #filename and can also be used as a link like that

> Actually no need for a # icon next to filenames, just make it so when the user selects a file to open and read that sets the `#fragment` in the URL for that file, and clicking a line number does that for that line too

> make sure the line numbers do not intefere with the user's ability to copy and paste blocks of those files without including the line numbers in them

- Display line numbers for all text files with a table-based layout
- Each line number is a clickable permalink that updates URL fragment
- Fragment format: #filename--L33 for specific lines, #filename for files
- Clicking a file updates the URL fragment to that file
- Page loads with fragment auto-open the file and highlight the line
- Line numbers use user-select: none to prevent copy/paste interference
- Highlighted lines have a yellow background for visibility