### PR TITLE
Add fetch support to MicroPython demo

### DIFF
--- a/micropython.html
+++ b/micropython.html
@@ -450,11 +450,11 @@ print("Description:", data['description'])`
             }
         }
 
-        // Output capture
+        // Output capture - with linebuffer:true, each call is a complete line without \n
         function pushOutput(kind, text) {
             if (!text) return;
             if (activeCapture) {
-                activeCapture[kind] += text;
+                activeCapture[kind] += text + '\n';
             } else {
                 (kind === 'stderr' ? console.error : console.log)(text);
             }


### PR DESCRIPTION
> The quickjs.html demo has a fetch() mechanism which allows code in QuickJS to make fetch() calls
>
> Figure out if the same thing could be added to micropython.html
>
> Wether or not that is possible update micropython.html to have the same design as quickjs.html and also add comparable examples with similar buttons to run them

- Redesign micropython.html to match quickjs.html layout and styling
- Add fetch() capability via MicroPython's js module interop (import js; await js.fetch())
- Add example buttons with Python equivalents: Hello World, Factorial, Fibonacci, List Comprehensions, Dictionaries & JSON, Prime Numbers, String Fun, FizzBuzz, Sorting, Classes, and Fetch Data
- Add URL hash management for code sharing
- Add copy button for output
- Add keyboard shortcuts (Ctrl/Cmd+Enter to run, Tab for indentation)
- Add fetch test to the test suite
- Preserve existing Run Tests functionality

https://gisthost.github.io/?2c4d32513791acd6b1d9a5fed34a158d/index.html