### PR TITLE
Make analytics text links clickable

### DIFF
--- a/analytics.html
+++ b/analytics.html
@@ -112,8 +112,16 @@
 
         .slug {
             font-family: monospace;
-            color: #2563eb;
             word-break: break-all;
+        }
+
+        .slug a {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        .slug a:hover {
+            text-decoration: underline;
         }
 
         .count {
@@ -500,7 +508,7 @@
                 topPagesTable.innerHTML = top20.map((p, i) => `
                     <tr>
                         <td>${i + 1}</td>
-                        <td class="slug">${escapeHtml(p.slug)}</td>
+                        <td class="slug"><a href="https://tools.simonwillison.net${escapeHtml(p.slug)}">${escapeHtml(p.slug)}</a></td>
                         <td class="count">${p.count.toLocaleString()}</td>
                     </tr>
                 `).join('');
@@ -515,7 +523,7 @@
             } else {
                 recentVisitsTable.innerHTML = recent100.map(v => `
                     <tr>
-                        <td class="slug">${escapeHtml(v.slug)}</td>
+                        <td class="slug"><a href="https://tools.simonwillison.net${escapeHtml(v.slug)}">${escapeHtml(v.slug)}</a></td>
                         <td class="timestamp">${formatTime(v.timestamp)}</td>
                     </tr>
                 `).join('');


### PR DESCRIPTION
> All of the text like `/bluesky-thread` on the analytics.html page should be links to those pages e.g. `https://tools.simonwillison.net/bluesky-thread`

Convert the page slug text in both the "Most Visited Pages" and "Recent Visits" tables into anchor links pointing to https://tools.simonwillison.net

https://gisthost.github.io/?cc45274c73a0b245041c40462343df47/index.html