### PR TITLE
Fix bugs in omit-needless-words

### DIFF
--- a/omit-needless-words.html
+++ b/omit-needless-words.html
@@ -802,7 +802,8 @@ analyzeBtn.addEventListener('click', async () => {
 async function analyzeTextStream(text, apiKey) {
   // Get the current prompt template and substitute the text
   const promptTemplate = getCurrentPrompt();
-  const prompt = promptTemplate.replace('${text}', text);
+  // Use a function to avoid special replacement patterns ($&, $', etc.) being interpreted
+  const prompt = promptTemplate.replace('${text}', () => text);
 
   // Get the selected model
   const selectedModel = modelSelect.value;


### PR DESCRIPTION
- Fix variable shadowing: rename inner `text` to `deltaText` to avoid
  shadowing the function parameter
- Fix word count statistics: count actual words inside <del> tags
  instead of just counting the number of <del> elements (a single tag
  like <del>in order</del> contains 2 words, not 1)