### PR TITLE
Add bookmarklets collection page with View Anchors and View Source

### DIFF
--- a/bookmarklets.html
+++ b/bookmarklets.html
@@ -49,6 +49,12 @@
         .bookmarklet-card p {
             color: #555;
         }
+        .bookmarklet-buttons {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            margin: 15px 0;
+        }
         .bookmarklet-link {
             display: inline-block;
             background: #2c5aa0;
@@ -59,7 +65,6 @@
             font-weight: bold;
             font-size: 16px;
             cursor: grab;
-            margin: 15px 0;
         }
         .bookmarklet-link:hover {
             background: #1e3d6f;
@@ -68,17 +73,14 @@
             cursor: grabbing;
         }
         .copy-btn {
-            display: inline-block;
-            margin-left: 10px;
             padding: 12px 20px;
             background: #666;
             color: white;
             border: none;
             border-radius: 6px;
             cursor: pointer;
-            font-size: 14px;
+            font-size: 16px;
             font-weight: bold;
-            vertical-align: top;
         }
         .copy-btn:hover {
             background: #555;
@@ -200,8 +202,10 @@
             </ul>
         </div>
 
-        <a class="bookmarklet-link" href="javascript:(function(){if(document.getElementById('__anchor_styles')){return}const style=document.createElement('style');style.id='__anchor_styles';style.textContent=`.__anchor_link{position:relative;text-decoration:none!important;color:#2c5aa0!important;font-weight:bold;font-size:0.9em;margin-right:4px;padding:2px 5px;border-radius:3px;background:rgba(44,90,160,0.1);opacity:0.7;transition:opacity 0.2s,background 0.2s}.__anchor_link:hover{opacity:1;background:rgba(44,90,160,0.2)}.__anchor_added{scroll-margin-top:20px}`;document.head.appendChild(style);const anchors=new Set();document.querySelectorAll('[id]').forEach(el=>{if(el.id&&!el.id.startsWith('__anchor'))anchors.add(el)});document.querySelectorAll('a[name]').forEach(el=>{if(el.getAttribute('name'))anchors.add(el)});let count=0;anchors.forEach(el=>{if(el.querySelector('.__anchor_link'))return;const id=el.id||el.getAttribute('name');if(!id)return;const link=document.createElement('a');link.className='__anchor_link';link.href='#'+id;link.textContent='#';link.title='Click to copy link to #'+id;link.onclick=function(e){e.preventDefault();e.stopPropagation();const url=location.href.split('#')[0]+'#'+id;navigator.clipboard.writeText(url).then(()=>{link.textContent='\u2713';setTimeout(()=>link.textContent='#',1500)}).catch(()=>{prompt('Copy this URL:',url)})};el.classList.add('__anchor_added');if(el.firstChild){el.insertBefore(link,el.firstChild)}else{el.appendChild(link)}count++});alert('Found '+count+' anchor points on this page')})();">View Anchors</a>
-        <button class="copy-btn" data-target="anchors">Copy</button>
+        <div class="bookmarklet-buttons">
+            <a class="bookmarklet-link" href="javascript:(function(){if(document.getElementById('__anchor_styles')){return}const style=document.createElement('style');style.id='__anchor_styles';style.textContent=`.__anchor_link{position:relative;text-decoration:none!important;color:#2c5aa0!important;font-weight:bold;font-size:0.9em;margin-right:4px;padding:2px 5px;border-radius:3px;background:rgba(44,90,160,0.1);opacity:0.7;transition:opacity 0.2s,background 0.2s}.__anchor_link:hover{opacity:1;background:rgba(44,90,160,0.2)}.__anchor_added{scroll-margin-top:20px}`;document.head.appendChild(style);const anchors=new Set();document.querySelectorAll('[id]').forEach(el=>{if(el.id&&!el.id.startsWith('__anchor'))anchors.add(el)});document.querySelectorAll('a[name]').forEach(el=>{if(el.getAttribute('name'))anchors.add(el)});let count=0;anchors.forEach(el=>{if(el.querySelector('.__anchor_link'))return;const id=el.id||el.getAttribute('name');if(!id)return;const link=document.createElement('a');link.className='__anchor_link';link.href='#'+id;link.textContent='#';link.title='Click to copy link to #'+id;link.onclick=function(e){e.preventDefault();e.stopPropagation();const url=location.href.split('#')[0]+'#'+id;navigator.clipboard.writeText(url).then(()=>{link.textContent='\u2713';setTimeout(()=>link.textContent='#',1500)}).catch(()=>{prompt('Copy this URL:',url)})};el.classList.add('__anchor_added');if(el.firstChild){el.insertBefore(link,el.firstChild)}else{el.appendChild(link)}count++});alert('Found '+count+' anchor points on this page')})();">View Anchors</a>
+            <button class="copy-btn" data-target="anchors">Copy</button>
+        </div>
 
         <details>
             <summary>View source code</summary>
@@ -309,8 +313,10 @@
             </ul>
         </div>
 
-        <a class="bookmarklet-link" href="javascript:(function(){if(document.getElementById('__viewsource_modal')){document.getElementById('__viewsource_modal').remove();return}const overlay=document.createElement('div');overlay.id='__viewsource_modal';overlay.innerHTML=`<style>#__viewsource_modal{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.7);z-index:999999;display:flex;align-items:center;justify-content:center;font-family:-apple-system,BlinkMacSystemFont,sans-serif}#__viewsource_box{background:#fff;border-radius:8px;width:90vw;height:85vh;max-width:1200px;display:flex;flex-direction:column;box-shadow:0 4px 20px rgba(0,0,0,0.3)}#__viewsource_header{padding:15px 20px;border-bottom:1px solid #ddd;display:flex;justify-content:space-between;align-items:center}#__viewsource_header h2{margin:0;font-size:18px;color:#333}#__viewsource_buttons{display:flex;gap:10px}#__viewsource_buttons button{padding:8px 16px;border:none;border-radius:4px;cursor:pointer;font-size:14px;font-weight:500}#__viewsource_pretty{background:#2c5aa0;color:#fff}#__viewsource_pretty:hover{background:#1e3d6f}#__viewsource_copy{background:#28a745;color:#fff}#__viewsource_copy:hover{background:#218838}#__viewsource_close{background:#dc3545;color:#fff}#__viewsource_close:hover{background:#c82333}#__viewsource_textarea{flex:1;margin:0;padding:15px;border:none;resize:none;font-family:'SF Mono',Monaco,'Cascadia Code',Consolas,monospace;font-size:13px;line-height:1.5;white-space:pre;overflow:auto}</style><div id='__viewsource_box'><div id='__viewsource_header'><h2>Page Source</h2><div id='__viewsource_buttons'><button id='__viewsource_pretty'>Pretty Print</button><button id='__viewsource_copy'>Copy</button><button id='__viewsource_close'>\u2715 Close</button></div></div><textarea id='__viewsource_textarea' readonly></textarea></div>`;document.body.appendChild(overlay);const textarea=document.getElementById('__viewsource_textarea');const html=document.documentElement.outerHTML;textarea.value=html;document.getElementById('__viewsource_close').onclick=()=>overlay.remove();overlay.onclick=(e)=>{if(e.target===overlay)overlay.remove()};document.addEventListener('keydown',function esc(e){if(e.key==='Escape'){overlay.remove();document.removeEventListener('keydown',esc)}});document.getElementById('__viewsource_copy').onclick=function(){textarea.select();navigator.clipboard.writeText(textarea.value).then(()=>{this.textContent='Copied!';setTimeout(()=>this.textContent='Copy',1500)}).catch(()=>{document.execCommand('copy');this.textContent='Copied!';setTimeout(()=>this.textContent='Copy',1500)})};document.getElementById('__viewsource_pretty').onclick=function(){const raw=textarea.value;let formatted='';let indent=0;const tab='  ';const rawLines=raw.replace(/>\s*</g,'>\n<').split('\n');rawLines.forEach(line=>{line=line.trim();if(!line)return;if(line.match(/^<\//)){ indent=Math.max(0,indent-1)}formatted+=tab.repeat(indent)+line+'\n';if(line.match(/^<[a-z][^>]*[^\/]>$/i)&&!line.match(/^<(area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)/i)){indent++}});textarea.value=formatted.trim();this.textContent='Done!';this.disabled=true}})();">View Source</a>
-        <button class="copy-btn" data-target="source">Copy</button>
+        <div class="bookmarklet-buttons">
+            <a class="bookmarklet-link" href="javascript:(function(){if(document.getElementById('__viewsource_modal')){document.getElementById('__viewsource_modal').remove();return}const overlay=document.createElement('div');overlay.id='__viewsource_modal';overlay.innerHTML=`<style>#__viewsource_modal{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.7);z-index:999999;display:flex;align-items:center;justify-content:center;font-family:-apple-system,BlinkMacSystemFont,sans-serif}#__viewsource_box{background:#fff;border-radius:8px;width:90vw;height:85vh;max-width:1200px;display:flex;flex-direction:column;box-shadow:0 4px 20px rgba(0,0,0,0.3)}#__viewsource_header{padding:15px 20px;border-bottom:1px solid #ddd;display:flex;justify-content:space-between;align-items:center}#__viewsource_header h2{margin:0;font-size:18px;color:#333}#__viewsource_buttons{display:flex;gap:10px}#__viewsource_buttons button{padding:8px 16px;border:none;border-radius:4px;cursor:pointer;font-size:14px;font-weight:500}#__viewsource_pretty{background:#2c5aa0;color:#fff}#__viewsource_pretty:hover{background:#1e3d6f}#__viewsource_copy{background:#28a745;color:#fff}#__viewsource_copy:hover{background:#218838}#__viewsource_close{background:#dc3545;color:#fff}#__viewsource_close:hover{background:#c82333}#__viewsource_textarea{flex:1;margin:0;padding:15px;border:none;resize:none;font-family:'SF Mono',Monaco,'Cascadia Code',Consolas,monospace;font-size:13px;line-height:1.5;white-space:pre;overflow:auto}</style><div id='__viewsource_box'><div id='__viewsource_header'><h2>Page Source</h2><div id='__viewsource_buttons'><button id='__viewsource_pretty'>Pretty Print</button><button id='__viewsource_copy'>Copy</button><button id='__viewsource_close'>\u2715 Close</button></div></div><textarea id='__viewsource_textarea' readonly></textarea></div>`;document.body.appendChild(overlay);const textarea=document.getElementById('__viewsource_textarea');const html=document.documentElement.outerHTML;textarea.value=html;document.getElementById('__viewsource_close').onclick=()=>overlay.remove();overlay.onclick=(e)=>{if(e.target===overlay)overlay.remove()};document.addEventListener('keydown',function esc(e){if(e.key==='Escape'){overlay.remove();document.removeEventListener('keydown',esc)}});document.getElementById('__viewsource_copy').onclick=function(){textarea.select();navigator.clipboard.writeText(textarea.value).then(()=>{this.textContent='Copied!';setTimeout(()=>this.textContent='Copy',1500)}).catch(()=>{document.execCommand('copy');this.textContent='Copied!';setTimeout(()=>this.textContent='Copy',1500)})};document.getElementById('__viewsource_pretty').onclick=function(){const raw=textarea.value;let formatted='';let indent=0;const tab='  ';const rawLines=raw.replace(/>\s*</g,'>\n<').split('\n');rawLines.forEach(line=>{line=line.trim();if(!line)return;if(line.match(/^<\//)){ indent=Math.max(0,indent-1)}formatted+=tab.repeat(indent)+line+'\n';if(line.match(/^<[a-z][^>]*[^\/]>$/i)&&!line.match(/^<(area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)/i)){indent++}});textarea.value=formatted.trim();this.textContent='Done!';this.disabled=true}})();">View Source</a>
+            <button class="copy-btn" data-target="source">Copy</button>
+        </div>
 
         <details>
             <summary>View source code</summary>


### PR DESCRIPTION
> Look at how the lobsters bookmarklet page works, then start a new bookmarklets.html page that uses the same install mechanism but is designed to support multiple bookmarklets going forward
> 
> Add two bookmarklets there:
> 
> - View reference anchors: finds all elements with an id=”” or a `<a name=”…”` and adds a visible # link as the first thing inside that element to help people link to otherwise invisible reference targets
> - View source - opens an HTML model with a textarea containing document.innerHTML - with a “pretty print” button that pretty prints it and a copy to clipboard button