### PR TITLE
Group related Claude models with visual styling

### DIFF
--- a/claude-token-counter.html
+++ b/claude-token-counter.html
@@ -111,6 +111,7 @@
     flex-wrap: wrap;
     gap: 8px 16px;
     margin: 8px 0;
+    align-items: flex-start;
   }
 
   .model-list label {
@@ -124,6 +125,28 @@
 
   .model-list input[type="checkbox"] {
     margin: 0;
+  }
+
+  .model-group {
+    border: 1px dashed #9bb4d9;
+    background: #f0f6ff;
+    border-radius: 6px;
+    padding: 8px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .model-group-note {
+    font-size: 12px;
+    color: #3b5a8a;
+    font-style: italic;
+  }
+
+  .model-group-items {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 14px;
   }
 
   .results-table {
@@ -203,12 +226,18 @@
 
 <script type="module">
 const API_URL = 'https://api.anthropic.com/v1/messages/count_tokens'
-const MODELS = [
-  'claude-opus-4-7',
-  'claude-opus-4-6',
-  'claude-opus-4-5',
-  'claude-sonnet-4-6',
-  'claude-haiku-4-5'
+const MODEL_ENTRIES = [
+  { type: 'model', id: 'claude-opus-4-7' },
+  {
+    type: 'group',
+    note: 'These models share the same tokenizer',
+    models: [
+      'claude-opus-4-6',
+      'claude-opus-4-5',
+      'claude-sonnet-4-6',
+      'claude-haiku-4-5'
+    ]
+  }
 ]
 const DEFAULT_MODEL = 'claude-opus-4-7'
 
@@ -371,12 +400,28 @@ const dropArea = document.getElementById('dropArea')
 const fileInput = document.getElementById('fileInput')
 const modelList = document.getElementById('modelList')
 
-modelList.innerHTML = MODELS.map(m => `
-  <label>
-    <input type="checkbox" value="${m}" ${m === DEFAULT_MODEL ? 'checked' : ''}>
-    ${m}
-  </label>
-`).join('')
+function renderCheckbox(model) {
+  return `
+    <label>
+      <input type="checkbox" value="${model}" ${model === DEFAULT_MODEL ? 'checked' : ''}>
+      ${model}
+    </label>
+  `
+}
+
+modelList.innerHTML = MODEL_ENTRIES.map(entry => {
+  if (entry.type === 'model') {
+    return renderCheckbox(entry.id)
+  }
+  return `
+    <div class="model-group">
+      <div class="model-group-items">
+        ${entry.models.map(renderCheckbox).join('')}
+      </div>
+      <div class="model-group-note">${entry.note}</div>
+    </div>
+  `
+}).join('')
 
 // File upload handling
 dropArea.addEventListener('click', () => fileInput.click())


### PR DESCRIPTION
> Add a note to claude-token-counter.html saying that claude-opus-4-6
> claude-opus-4-5
> claude-sonnet-4-6
> claude-haiku-4-5
> all have the same tokenizer, visually group them to help emphasize that but still allow them to be separately seelcted

## Summary
Reorganized the model selection UI to group related Claude models together with a visual container and explanatory note, improving clarity about model tokenizer compatibility.

## Key Changes
- Restructured `MODELS` array into `MODEL_ENTRIES` with support for both individual models and grouped models
- Added new CSS classes for model grouping:
  - `.model-group`: Styled container with dashed border and light blue background
  - `.model-group-note`: Italic text for explanatory notes about grouped models
  - `.model-group-items`: Flex container for grouped model checkboxes
- Updated model list rendering logic to handle both individual and grouped model entries
- Extracted checkbox rendering into a reusable `renderCheckbox()` function
- Added `align-items: flex-start` to `.model-list` for better alignment with grouped items
- Grouped `claude-opus-4-6`, `claude-opus-4-5`, `claude-sonnet-4-6`, and `claude-haiku-4-5` under a note indicating they share the same tokenizer

## Implementation Details
The new `MODEL_ENTRIES` structure allows flexible model organization:
- Individual models use `{ type: 'model', id: 'model-name' }`
- Grouped models use `{ type: 'group', note: 'description', models: [...] }`

The rendering logic conditionally generates either a simple checkbox or a styled group container based on entry type, maintaining backward compatibility with the existing token counting functionality.

https://claude.ai/code/session_01TQ3FBzSiX1zMauBQMsSnTB