### PR TITLE
Add explanation of token counter tool on claude-token-counter page

### DIFF
--- a/claude-token-counter.html
+++ b/claude-token-counter.html
@@ -198,7 +198,9 @@
 </head>
 <body>
   <h1>Claude Token Counter</h1>
-  
+
+  <p>This tool uses your Anthropic API key to count tokens in text and images using <a href="https://platform.claude.com/docs/en/build-with-claude/token-counting">Anthropic's token counting API</a>.</p>
+
   <div class="input-group">
     <label for="system">System prompt:</label>
     <textarea id="system" style="min-height: 100px" placeholder="Enter system prompt (optional)"></textarea>


### PR DESCRIPTION
> Add explanatory text to the top of the page on claude-token-counter explaining that is uses your Anthropic API key to count tokens in text and images using Anthropic’s token counting API - and link to https://platform.claude.com/docs/en/build-with-claude/token-counting