### PR TITLE
Remove TIL content type from blog-to-newsletter

### DIFF
--- a/blog-to-newsletter.html
+++ b/blog-to-newsletter.html
@@ -363,7 +363,7 @@
   <div class="buttons">
     <button class="primary-btn" id="copyRichText">Copy rich text newsletter to clipboard</button>
     <button class="primary-btn" id="copyHtml">Copy HTML newsletter to clipboard</button>
-    <button class="secondary-btn" id="copyLinksOnly">Copy just the links/quotes/TILs</button>
+    <button class="secondary-btn" id="copyLinksOnly">Copy just the links/quotes/beats</button>
   </div>
 
   <div class="html-length" id="htmlLength"></div>
@@ -396,7 +396,6 @@
       let entries = [];
       let blogmarks = [];
       let quotations = [];
-      let tils = [];
       let notes = [];
       let chapters = [];
       let beats = [];
@@ -582,17 +581,6 @@ with content as (
     url as external_url
   from blog_beat
   where coalesce(note, '') != '' and is_draft = 0
-  union all
-  select
-    rowid,
-    'til' as type,
-    title,
-    created,
-    'null' as slug,
-    '<p><strong>TIL</strong> ' || date(created) || ' <a href="'|| 'https://til.simonwillison.net/' || topic || '/' || slug || '">' || title || '</a>:' || ' ' || substr(html, 1, instr(html, '</p>') - 1) || ' &#8230;</p>' as html,
-    'null' as json,
-    'https://til.simonwillison.net/' || topic || '/' || slug as external_url
-  from til
 ),
 collected as (
   select
@@ -600,7 +588,7 @@ collected as (
     type,
     title,
     case
-      when type in ('til', 'chapter')
+      when type = 'chapter'
       then external_url
       else 'https://simonwillison.net/' || strftime('%Y/', created)
       || substr('JanFebMarAprMayJunJulAugSepOctNovDec', (strftime('%m', created) - 1) * 3 + 1, 3) ||
@@ -841,7 +829,6 @@ order by
         entries = content.filter(e => e.type === 'entry');
         blogmarks = content.filter(e => e.type === 'blogmark');
         quotations = content.filter(e => e.type === 'quotation');
-        tils = content.filter(e => e.type === 'til');
         notes = content.filter(e => e.type === 'note');
         chapters = content.filter(e => e.type === 'chapter');
         beats = content.filter(e => e.type === 'beat');
@@ -1075,9 +1062,6 @@ order by
         if (quotations.length) {
           extras.push(`${quotations.length} quotation${quotations.length > 1 ? 's' : ''}`);
         }
-        if (tils.length) {
-          extras.push(`${tils.length} TIL${tils.length > 1 ? 's' : ''}`);
-        }
         if (notes.length) {
           extras.push(`${notes.length} note${notes.length > 1 ? 's' : ''}`);
         }
@@ -1134,7 +1118,6 @@ order by
         content = content.filter(e => !(e.type === type && String(e.id) === String(id)));
         blogmarks = blogmarks.filter(e => !(type === 'blogmark' && String(e.id) === String(id)));
         quotations = quotations.filter(e => !(type === 'quotation' && String(e.id) === String(id)));
-        tils = tils.filter(e => !(type === 'til' && String(e.id) === String(id)));
         notes = notes.filter(e => !(type === 'note' && String(e.id) === String(id)));
         chapters = chapters.filter(e => !(type === 'chapter' && String(e.id) === String(id)));
         beats = beats.filter(e => !(type === 'beat' && String(e.id) === String(id)));


### PR DESCRIPTION
> In blog-to-newsletter TILs are currently duplicated - they come through as TILs and as beats. Drop the TILs version, we will just use Beats from now on. Update the "Copy just the links/quotes/TILs" button to be "Copy just the links/quotes/beats" instead.

## Summary
This PR removes support for the "TIL" (Today I Learned) content type from the blog-to-newsletter tool. The TIL content type is being deprecated in favor of the existing "beats" content type.

## Key Changes
- Removed the SQL query that fetches TIL entries from the `til` table
- Removed the `tils` array variable and all related filtering logic
- Updated the button label from "Copy just the links/quotes/TILs" to "Copy just the links/quotes/beats"
- Removed TIL-specific URL handling logic (TILs no longer receive special external_url treatment)
- Removed the TIL count display from the newsletter summary statistics

## Implementation Details
- The SQL `UNION ALL` clause that queried the `til` table has been completely removed
- The conditional logic that treated TILs and chapters specially for URL generation has been simplified to only handle chapters
- All JavaScript code that filtered, tracked, and displayed TIL content has been removed
- The removal is clean with no orphaned references remaining

https://claude.ai/code/session_01LVAnL3k8fmeYEo7dJJRjJj