### PR TITLE
Refactor size parameter handling in OpenAI image CLI

### DIFF
--- a/python/openai_image.py
+++ b/python/openai_image.py
@@ -109,7 +109,7 @@ def literal_choices(annotation) -> list[str]:
 
 # ----------------------------- CLI construction -----------------------------
 
-PARAMS = ["background", "moderation", "output_format", "quality", "size"]
+PARAMS = ["background", "moderation", "output_format", "quality"]
 
 
 def build_command() -> click.Command:
@@ -121,6 +121,7 @@ def build_command() -> click.Command:
 
     # model choices are “known” but we don’t enforce them; we just show in help
     model_choices = literal_choices(hints.get("model", str))
+    size_choices = literal_choices(hints.get("size", str))
 
     params: list[click.Parameter] = []
 
@@ -150,7 +151,13 @@ def build_command() -> click.Command:
         )
     )
 
-    # Derive options (background/moderation/output_format/quality/size) with choices from Literal
+    # --size (not restricted, but show known values)
+    size_help = "size"
+    if size_choices:
+        size_help += f" (known: {', '.join(size_choices)})"
+    params.append(click.Option(["--size"], help=size_help))
+
+    # Derive options (background/moderation/output_format/quality) with choices from Literal
     for name in PARAMS:
         ann = hints.get(name)
         label = name.replace("_", " ")
@@ -181,6 +188,7 @@ def build_command() -> click.Command:
         prompt: str = kw.pop("prompt")
         outfile: Path | None = kw.pop("outfile", None)
         model: str = kw.pop("model")
+        size: str | None = kw.pop("size", None)
 
         if outfile is None:
             # Default: /tmp/image-<6 hex>.png
@@ -189,6 +197,8 @@ def build_command() -> click.Command:
 
         # Prepare kwargs for Images.generate (drop Nones)
         gen_kwargs = {"model": model}
+        if size is not None:
+            gen_kwargs["size"] = size
         for p in PARAMS:
             v = kw.get(p, None)
             if v is not None:


### PR DESCRIPTION
> Modify openai_image.py so it no longer validates the --size option and instead sends it straight to the model, like it does with -m

## Summary
Refactored the `--size` parameter in the OpenAI image CLI to be handled separately from other derived options, allowing it to accept any value while still displaying known size options in the help text.

## Key Changes
- Removed `"size"` from the `PARAMS` list to exclude it from the standard derived options loop
- Added explicit `--size` option construction that:
  - Extracts known size choices from type hints
  - Displays known values in help text without restricting input to those values
  - Allows users to pass arbitrary size values if needed
- Updated the callback function to:
  - Extract the `size` parameter separately from other parameters
  - Conditionally include `size` in the `gen_kwargs` only when provided (not None)
- Updated comments to reflect that derived options now only include background/moderation/output_format/quality

## Implementation Details
The change allows the `--size` parameter to be more flexible than other options - it shows known values as a reference but doesn't enforce them as strict choices, which may be useful for forward compatibility with new size options from the OpenAI API.

https://claude.ai/code/session_01Dvefz27EfUQjytFanABNaB