### PR TITLE
Add Copy rich text button to render-markdown

### DIFF
--- a/render-markdown.html
+++ b/render-markdown.html
@@ -75,15 +75,18 @@
       background-color: #0253b3;
     }
 
-    #copy-button {
+    #copy-button,
+    #copy-rich-button {
       background: #2ea44f;
     }
 
-    #copy-button:hover {
+    #copy-button:hover,
+    #copy-rich-button:hover {
       background: #22863a;
     }
 
-    #copy-button.success {
+    #copy-button.success,
+    #copy-rich-button.success {
       background: #22863a;
     }
 
@@ -349,6 +352,7 @@
   
   <h3>HTML Output</h3>
   <button id="copy-button">Copy HTML</button>
+  <button id="copy-rich-button">Copy rich text</button>
   
   <div class="output-container">
     <textarea id="output"></textarea>
@@ -512,6 +516,47 @@ copyButton.addEventListener('click', async () => {
     copyButton.textContent = 'Failed to copy';
     setTimeout(() => {
       copyButton.textContent = 'Copy HTML';
+    }, 2000);
+  }
+});
+
+// Add copy rich text functionality
+const copyRichButton = document.getElementById('copy-rich-button');
+
+function copyRichText(htmlContent) {
+  const tempElement = document.createElement('div');
+  tempElement.innerHTML = htmlContent;
+  document.body.appendChild(tempElement);
+
+  const range = document.createRange();
+  range.selectNode(tempElement);
+
+  const selection = window.getSelection();
+  selection.removeAllRanges();
+  selection.addRange(range);
+
+  document.execCommand('copy');
+
+  selection.removeAllRanges();
+  document.body.removeChild(tempElement);
+}
+
+copyRichButton.addEventListener('click', () => {
+  if (!output.value) {
+    return;
+  }
+  try {
+    copyRichText(output.value);
+    copyRichButton.textContent = 'Copied!';
+    copyRichButton.classList.add('success');
+    setTimeout(() => {
+      copyRichButton.textContent = 'Copy rich text';
+      copyRichButton.classList.remove('success');
+    }, 2000);
+  } catch (err) {
+    copyRichButton.textContent = 'Failed to copy';
+    setTimeout(() => {
+      copyRichButton.textContent = 'Copy rich text';
     }, 2000);
   }
 });


### PR DESCRIPTION
> Modify render-markdown to add a copy rich text button next to the copy html button, it should use the same mechanism as blog to newsletter

Uses the same execCommand-based mechanism as blog-to-newsletter to
copy rendered HTML as rich text for pasting into editors like Substack.