### PR TITLE
Add image-gallery web component, use it in inat-sightings

### DIFF
--- a/image-gallery-component.js
+++ b/image-gallery-component.js
@@ -77,6 +77,16 @@ image-gallery:defined figcaption {
   text-overflow: ellipsis;
 }
 
+image-gallery:defined figcaption a {
+  pointer-events: auto;
+  color: inherit;
+  text-decoration: underline;
+}
+
+image-gallery:defined figcaption a:hover {
+  color: #cfe8ff;
+}
+
 image-gallery:defined[data-count="1"] {
   justify-content: center;
 }
@@ -188,6 +198,16 @@ dialog.gallery-modal::backdrop {
   padding: 12px 72px;
   z-index: 1;
   pointer-events: none;
+}
+
+.gallery-modal-caption a {
+  pointer-events: auto;
+  color: #9cf;
+  text-decoration: underline;
+}
+
+.gallery-modal-caption a:hover {
+  color: #cfe8ff;
 }
 
 .gallery-modal-counter {
@@ -387,7 +407,12 @@ class ImageGallery extends HTMLElement {
     img.alt = thumb ? thumb.alt : '';
 
     const cap = ImageGallery.modal.querySelector('.gallery-modal-caption');
-    cap.textContent = caption ? caption.textContent : '';
+    cap.replaceChildren();
+    if (caption) {
+      for (const node of caption.childNodes) {
+        cap.appendChild(node.cloneNode(true));
+      }
+    }
 
     // Counter is opt-in via show-counter on the figure's parent gallery
     const parent = figure.closest('image-gallery');

--- a/image-gallery-component.js
+++ b/image-gallery-component.js
@@ -352,23 +352,24 @@ class ImageGallery extends HTMLElement {
   }
 
   getRowSplits(n) {
-    const fixed = {
-      2: [2], 3: [3], 4: [4],
-      5: [2, 3], 6: [3, 3], 7: [3, 4], 8: [4, 4],
-      9: [3, 3, 3], 10: [3, 3, 4], 11: [3, 4, 4], 12: [4, 4, 4]
-    };
-    if (fixed[n]) return fixed[n];
-
-    // Beyond 12: prefer rows of 4, with smaller leading rows when needed
+    if (n <= 3) return [n];
+    // Cap rows at 3 wide. Use rows of 3 plus rows of 2 to make up the
+    // remainder; smaller rows lead so the bottom row is the widest.
     const splits = [];
-    let remaining = n;
-    while (remaining > 0) {
-      if (remaining <= 4) { splits.push(remaining); break; }
-      if (remaining === 5) { splits.push(2); remaining = 3; }
-      else if (remaining === 6) { splits.push(3); remaining = 3; }
-      else if (remaining === 7) { splits.push(3); remaining = 4; }
-      else { splits.push(4); remaining -= 4; }
+    const rem = n % 3;
+    let twos, threes;
+    if (rem === 0) {
+      twos = 0;
+      threes = n / 3;
+    } else if (rem === 1) {
+      twos = 2;
+      threes = (n - 4) / 3;
+    } else {
+      twos = 1;
+      threes = (n - 2) / 3;
     }
+    for (let i = 0; i < twos; i++) splits.push(2);
+    for (let i = 0; i < threes; i++) splits.push(3);
     return splits;
   }
 

--- a/image-gallery-component.js
+++ b/image-gallery-component.js
@@ -1,0 +1,477 @@
+/**
+ * <image-gallery> web component
+ *
+ * Lays out a list of <figure> children in justified rows: items in a row
+ * share a common height, with widths proportional to each image's aspect
+ * ratio. Handles mixed portrait / landscape mixes naturally.
+ *
+ * Clicking any image opens a full-screen lightbox with prev / next
+ * navigation (arrow keys, swipe on touch devices, on-screen arrows). All
+ * <image-gallery> elements on the page form a single navigation cycle and
+ * the figure list is recomputed on every step, so galleries added or
+ * removed after load are picked up automatically.
+ *
+ * Markup:
+ *   <image-gallery>
+ *     <figure>
+ *       <a href="full.jpg"><img src="thumb.jpg" alt="..."></a>
+ *       <figcaption>caption text</figcaption>
+ *     </figure>
+ *     ...
+ *   </image-gallery>
+ *
+ * Attributes:
+ *   show-counter   Display "n / total" position counter in the lightbox
+ *                  while viewing a figure from this gallery.
+ */
+
+const STYLES = `
+image-gallery:defined {
+  --gap: 6px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--gap);
+  background: #f4f4f4;
+  padding: var(--gap);
+  border-radius: 4px;
+}
+
+image-gallery:defined > figure {
+  margin: 0;
+  position: relative;
+  overflow: hidden;
+  background: #ddd;
+  border-radius: 2px;
+  min-width: 0;
+}
+
+image-gallery:defined > figure > a {
+  display: block;
+  width: 100%;
+  height: 100%;
+  text-decoration: none;
+  cursor: zoom-in;
+}
+
+image-gallery:defined img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+image-gallery:defined figcaption {
+  position: absolute;
+  bottom: 4px;
+  left: 4px;
+  right: 4px;
+  margin: 0;
+  padding: 2px 6px;
+  font-size: 11px;
+  color: white;
+  background: rgba(0, 0, 0, 0.55);
+  border-radius: 2px;
+  pointer-events: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+image-gallery:defined[data-count="1"] {
+  justify-content: center;
+}
+
+image-gallery:defined[data-count="1"] > figure {
+  width: 100%;
+}
+
+image-gallery:defined[data-count="1"][data-orientation="portrait"] > figure {
+  width: auto;
+  max-width: 100%;
+}
+
+dialog.gallery-modal {
+  border: none;
+  padding: 0;
+  margin: 0;
+  width: 100vw;
+  height: 100vh;
+  max-width: 100vw;
+  max-height: 100vh;
+  background: #000;
+  color: #fff;
+  overflow: hidden;
+}
+
+dialog.gallery-modal::backdrop {
+  background: rgba(0, 0, 0, 0.95);
+}
+
+.gallery-modal-stage {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  touch-action: pan-y;
+}
+
+.gallery-modal-img {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  display: block;
+  user-select: none;
+  -webkit-user-drag: none;
+  pointer-events: none;
+}
+
+.gallery-modal-btn {
+  position: absolute;
+  background: transparent;
+  border: none;
+  color: rgba(255, 255, 255, 0.55);
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  transition: color 0.15s ease, background 0.15s ease;
+  z-index: 2;
+  font-family: inherit;
+}
+
+.gallery-modal-btn:hover,
+.gallery-modal-btn:focus-visible {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.12);
+  outline: none;
+}
+
+.gallery-modal-btn svg {
+  width: 24px;
+  height: 24px;
+  display: block;
+}
+
+.gallery-modal-close {
+  top: 12px;
+  right: 12px;
+  width: 44px;
+  height: 44px;
+}
+
+.gallery-modal-prev,
+.gallery-modal-next {
+  top: 50%;
+  transform: translateY(-50%);
+  width: 56px;
+  height: 56px;
+}
+
+.gallery-modal-prev {
+  left: 8px;
+}
+
+.gallery-modal-next {
+  right: 8px;
+}
+
+.gallery-modal-caption-wrap {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.65);
+  padding: 12px 72px;
+  z-index: 1;
+  pointer-events: none;
+}
+
+.gallery-modal-counter {
+  display: block;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: rgba(255, 255, 255, 0.55);
+  margin-bottom: 2px;
+}
+
+.gallery-modal-counter[hidden] {
+  display: none;
+}
+
+.gallery-modal-caption {
+  font-size: 14px;
+  line-height: 1.4;
+  color: #fff;
+  word-wrap: break-word;
+}
+
+@media (max-width: 600px) {
+  .gallery-modal-prev,
+  .gallery-modal-next {
+    width: 44px;
+    height: 44px;
+  }
+
+  .gallery-modal-caption-wrap {
+    padding: 10px 16px 14px;
+  }
+}
+`;
+
+function injectStyles() {
+  if (document.getElementById('image-gallery-styles')) return;
+  const style = document.createElement('style');
+  style.id = 'image-gallery-styles';
+  style.textContent = STYLES;
+  document.head.appendChild(style);
+}
+
+class ImageGallery extends HTMLElement {
+  static instances = new Set();
+  static modal = null;
+  static currentFigure = null;
+
+  connectedCallback() {
+    this.figures = [...this.querySelectorAll(':scope > figure')];
+    if (!this.figures.length) return;
+    this.dataset.count = this.figures.length;
+
+    ImageGallery.instances.add(this);
+
+    // Wire up clicks on each figure's anchor: open the lightbox instead
+    this.figures.forEach(figure => {
+      const a = figure.querySelector('a');
+      if (a && !a.dataset.galleryWired) {
+        a.dataset.galleryWired = '1';
+        a.addEventListener('click', e => {
+          e.preventDefault();
+          ImageGallery.openFor(figure);
+        });
+      }
+    });
+
+    // Layout once images have natural dimensions available
+    const imgs = this.figures.map(f => f.querySelector('img')).filter(Boolean);
+    Promise.all(imgs.map(img => {
+      if (img.complete && img.naturalWidth > 0) return Promise.resolve();
+      return new Promise(res => {
+        img.addEventListener('load', res, { once: true });
+        img.addEventListener('error', res, { once: true });
+      });
+    })).then(() => this.applyLayout());
+  }
+
+  disconnectedCallback() {
+    ImageGallery.instances.delete(this);
+  }
+
+  ratioOf(figure) {
+    const img = figure.querySelector('img');
+    if (!img) return 1;
+    const r = img.naturalWidth / img.naturalHeight;
+    return isFinite(r) && r > 0 ? r : 1;
+  }
+
+  applyLayout() {
+    const ratios = this.figures.map(f => this.ratioOf(f));
+    const count = this.figures.length;
+
+    this.figures.forEach(f => {
+      f.style.width = '';
+      f.style.aspectRatio = '';
+      f.style.maxHeight = '';
+    });
+
+    if (count === 1) {
+      const f = this.figures[0];
+      const r = ratios[0];
+      this.dataset.orientation = r >= 1 ? 'landscape' : 'portrait';
+      f.style.aspectRatio = r;
+      if (r < 1) {
+        const maxH = Math.min(window.innerHeight * 0.75, 700);
+        f.style.maxHeight = maxH + 'px';
+      }
+      return;
+    }
+
+    const splits = this.getRowSplits(count);
+    let idx = 0;
+    splits.forEach(rowCount => {
+      const rowFigs = this.figures.slice(idx, idx + rowCount);
+      const rowRatios = ratios.slice(idx, idx + rowCount);
+      const sum = rowRatios.reduce((a, b) => a + b, 0);
+      rowFigs.forEach((f, i) => {
+        const fraction = rowRatios[i] / sum;
+        f.style.width = `calc((100% - ${rowCount - 1} * var(--gap)) * ${fraction})`;
+        f.style.aspectRatio = rowRatios[i];
+      });
+      idx += rowCount;
+    });
+  }
+
+  getRowSplits(n) {
+    const fixed = {
+      2: [2], 3: [3], 4: [4],
+      5: [2, 3], 6: [3, 3], 7: [3, 4], 8: [4, 4],
+      9: [3, 3, 3], 10: [3, 3, 4], 11: [3, 4, 4], 12: [4, 4, 4]
+    };
+    if (fixed[n]) return fixed[n];
+
+    // Beyond 12: prefer rows of 4, with smaller leading rows when needed
+    const splits = [];
+    let remaining = n;
+    while (remaining > 0) {
+      if (remaining <= 4) { splits.push(remaining); break; }
+      if (remaining === 5) { splits.push(2); remaining = 3; }
+      else if (remaining === 6) { splits.push(3); remaining = 3; }
+      else if (remaining === 7) { splits.push(3); remaining = 4; }
+      else { splits.push(4); remaining -= 4; }
+    }
+    return splits;
+  }
+
+  // ----- Cross-gallery flat list (in document order) -----
+
+  static getAllFigures() {
+    const sorted = [...ImageGallery.instances].sort((a, b) => {
+      if (a === b) return 0;
+      const pos = a.compareDocumentPosition(b);
+      if (pos & Node.DOCUMENT_POSITION_FOLLOWING) return -1;
+      if (pos & Node.DOCUMENT_POSITION_PRECEDING) return 1;
+      return 0;
+    });
+    const all = [];
+    sorted.forEach(g => {
+      [...g.querySelectorAll(':scope > figure')].forEach(f => all.push(f));
+    });
+    return all;
+  }
+
+  static openFor(figure) {
+    if (!figure) return;
+    if (!ImageGallery.modal) ImageGallery.buildModal();
+    ImageGallery.currentFigure = figure;
+    ImageGallery.renderModal();
+    if (!ImageGallery.modal.open) ImageGallery.modal.showModal();
+  }
+
+  static step(direction) {
+    // Recompute the list every step so newly-added galleries are picked up
+    const all = ImageGallery.getAllFigures();
+    if (!all.length) return;
+    const n = all.length;
+    let idx = all.indexOf(ImageGallery.currentFigure);
+    if (idx < 0) idx = 0; // current figure was removed; restart at 0
+    else idx = (idx + direction + n) % n;
+    ImageGallery.openFor(all[idx]);
+  }
+
+  static next() { ImageGallery.step(1); }
+  static prev() { ImageGallery.step(-1); }
+
+  static renderModal() {
+    const figure = ImageGallery.currentFigure;
+    if (!figure) return;
+    const a = figure.querySelector('a');
+    const thumb = figure.querySelector('img');
+    const caption = figure.querySelector('figcaption');
+    const fullSrc = a ? a.href : (thumb ? thumb.src : '');
+
+    const img = ImageGallery.modal.querySelector('.gallery-modal-img');
+    img.src = fullSrc;
+    img.alt = thumb ? thumb.alt : '';
+
+    const cap = ImageGallery.modal.querySelector('.gallery-modal-caption');
+    cap.textContent = caption ? caption.textContent : '';
+
+    // Counter is opt-in via show-counter on the figure's parent gallery
+    const parent = figure.closest('image-gallery');
+    const showCounter = parent && parent.hasAttribute('show-counter');
+    const counter = ImageGallery.modal.querySelector('.gallery-modal-counter');
+    counter.hidden = !showCounter;
+    if (showCounter) {
+      const all = ImageGallery.getAllFigures();
+      const idx = all.indexOf(figure);
+      counter.textContent = `${idx + 1} / ${all.length}`;
+    } else {
+      counter.textContent = '';
+    }
+  }
+
+  static buildModal() {
+    const dialog = document.createElement('dialog');
+    dialog.className = 'gallery-modal';
+    dialog.innerHTML = `
+      <div class="gallery-modal-stage">
+        <img class="gallery-modal-img" alt="">
+      </div>
+      <button type="button" class="gallery-modal-btn gallery-modal-prev" aria-label="Previous image">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 6 9 12 15 18"/></svg>
+      </button>
+      <button type="button" class="gallery-modal-btn gallery-modal-next" aria-label="Next image">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 6 15 12 9 18"/></svg>
+      </button>
+      <button type="button" class="gallery-modal-btn gallery-modal-close" aria-label="Close">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><line x1="6" y1="6" x2="18" y2="18"/><line x1="6" y1="18" x2="18" y2="6"/></svg>
+      </button>
+      <div class="gallery-modal-caption-wrap">
+        <span class="gallery-modal-counter" hidden></span>
+        <div class="gallery-modal-caption"></div>
+      </div>
+    `;
+
+    dialog.querySelector('.gallery-modal-close').addEventListener('click', () => dialog.close());
+    dialog.querySelector('.gallery-modal-prev').addEventListener('click', () => ImageGallery.prev());
+    dialog.querySelector('.gallery-modal-next').addEventListener('click', () => ImageGallery.next());
+
+    // Tap on stage background (not the image, not buttons) closes the modal
+    const stage = dialog.querySelector('.gallery-modal-stage');
+    stage.addEventListener('click', e => {
+      if (e.target === stage) dialog.close();
+    });
+
+    // Keyboard navigation while open
+    dialog.addEventListener('keydown', e => {
+      if (e.key === 'ArrowLeft') { e.preventDefault(); ImageGallery.prev(); }
+      else if (e.key === 'ArrowRight') { e.preventDefault(); ImageGallery.next(); }
+    });
+
+    // Single-finger horizontal swipe
+    let sx = null, sy = null, st = 0;
+    dialog.addEventListener('touchstart', e => {
+      if (e.touches.length === 1) {
+        sx = e.touches[0].clientX;
+        sy = e.touches[0].clientY;
+        st = Date.now();
+      } else {
+        sx = null;
+      }
+    }, { passive: true });
+
+    dialog.addEventListener('touchend', e => {
+      if (sx === null || e.changedTouches.length !== 1) { sx = null; return; }
+      const dx = e.changedTouches[0].clientX - sx;
+      const dy = e.changedTouches[0].clientY - sy;
+      const dt = Date.now() - st;
+      sx = null;
+      if (Math.abs(dx) > 50 && Math.abs(dx) > Math.abs(dy) * 1.5 && dt < 600) {
+        if (dx < 0) ImageGallery.next();
+        else ImageGallery.prev();
+      }
+    }, { passive: true });
+
+    document.body.appendChild(dialog);
+    ImageGallery.modal = dialog;
+  }
+}
+
+injectStyles();
+
+if (!customElements.get('image-gallery')) {
+  customElements.define('image-gallery', ImageGallery);
+}

--- a/image-gallery-component.js
+++ b/image-gallery-component.js
@@ -28,8 +28,10 @@
 const STYLES = `
 image-gallery:defined {
   --gap: 6px;
+  --max-row-height: 240px;
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
   gap: var(--gap);
   background: #f4f4f4;
   padding: var(--gap);
@@ -85,19 +87,6 @@ image-gallery:defined figcaption a {
 
 image-gallery:defined figcaption a:hover {
   color: #cfe8ff;
-}
-
-image-gallery:defined[data-count="1"] {
-  justify-content: center;
-}
-
-image-gallery:defined[data-count="1"] > figure {
-  width: 100%;
-}
-
-image-gallery:defined[data-count="1"][data-orientation="portrait"] > figure {
-  width: auto;
-  max-width: 100%;
 }
 
 dialog.gallery-modal {
@@ -275,7 +264,8 @@ class ImageGallery extends HTMLElement {
       }
     });
 
-    // Layout once images have natural dimensions available
+    // Layout once images have natural dimensions available, then keep
+    // it in sync with container width changes
     const imgs = this.figures.map(f => f.querySelector('img')).filter(Boolean);
     Promise.all(imgs.map(img => {
       if (img.complete && img.naturalWidth > 0) return Promise.resolve();
@@ -283,10 +273,22 @@ class ImageGallery extends HTMLElement {
         img.addEventListener('load', res, { once: true });
         img.addEventListener('error', res, { once: true });
       });
-    })).then(() => this.applyLayout());
+    })).then(() => {
+      this.applyLayout();
+      this._lastWidth = this.clientWidth;
+      this._ro = new ResizeObserver(entries => {
+        const w = entries[0].contentRect.width;
+        if (Math.abs(w - this._lastWidth) > 0.5) {
+          this._lastWidth = w;
+          this.applyLayout();
+        }
+      });
+      this._ro.observe(this);
+    });
   }
 
   disconnectedCallback() {
+    this._ro?.disconnect();
     ImageGallery.instances.delete(this);
   }
 
@@ -303,19 +305,32 @@ class ImageGallery extends HTMLElement {
 
     this.figures.forEach(f => {
       f.style.width = '';
+      f.style.height = '';
       f.style.aspectRatio = '';
       f.style.maxHeight = '';
     });
+
+    const cs = getComputedStyle(this);
+    const padL = parseFloat(cs.paddingLeft) || 0;
+    const padR = parseFloat(cs.paddingRight) || 0;
+    const gap = parseFloat(cs.gap) || 0;
+    const containerW = this.clientWidth - padL - padR;
+    const maxH = parseFloat(cs.getPropertyValue('--max-row-height')) || 240;
+
+    if (containerW <= 0) return;
 
     if (count === 1) {
       const f = this.figures[0];
       const r = ratios[0];
       this.dataset.orientation = r >= 1 ? 'landscape' : 'portrait';
-      f.style.aspectRatio = r;
-      if (r < 1) {
-        const maxH = Math.min(window.innerHeight * 0.75, 700);
-        f.style.maxHeight = maxH + 'px';
+      let h = maxH;
+      let w = h * r;
+      if (w > containerW) {
+        w = containerW;
+        h = w / r;
       }
+      f.style.width = w + 'px';
+      f.style.height = h + 'px';
       return;
     }
 
@@ -325,10 +340,12 @@ class ImageGallery extends HTMLElement {
       const rowFigs = this.figures.slice(idx, idx + rowCount);
       const rowRatios = ratios.slice(idx, idx + rowCount);
       const sum = rowRatios.reduce((a, b) => a + b, 0);
+      const rowAvailW = Math.max(0, containerW - (rowCount - 1) * gap);
+      const naturalH = sum > 0 ? rowAvailW / sum : maxH;
+      const rowH = Math.min(naturalH, maxH);
       rowFigs.forEach((f, i) => {
-        const fraction = rowRatios[i] / sum;
-        f.style.width = `calc((100% - ${rowCount - 1} * var(--gap)) * ${fraction})`;
-        f.style.aspectRatio = rowRatios[i];
+        f.style.width = (rowH * rowRatios[i]) + 'px';
+        f.style.height = rowH + 'px';
       });
       idx += rowCount;
     });

--- a/inat-sightings.html
+++ b/inat-sightings.html
@@ -156,8 +156,6 @@ function renderClump(clump) {
       if (obs.uri) {
         const link = document.createElement("a");
         link.href = obs.uri;
-        link.target = "_blank";
-        link.rel = "noopener";
         link.textContent = name;
         link.title = "View observation on iNaturalist";
         figcaption.appendChild(link);

--- a/inat-sightings.html
+++ b/inat-sightings.html
@@ -44,57 +44,6 @@
     font-size: 0.85rem;
     margin-top: 0.15rem;
   }
-  .photos {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-  }
-  .photo {
-    cursor: zoom-in;
-    border: 0;
-    padding: 0;
-    background: none;
-    display: block;
-    line-height: 0;
-  }
-  .photo img {
-    width: 120px;
-    height: 120px;
-    object-fit: cover;
-    border-radius: 6px;
-    background: #eee;
-  }
-  .photo-label {
-    font-size: 0.75rem;
-    color: #555;
-    text-align: center;
-    margin-top: 2px;
-    max-width: 120px;
-    line-height: 1.2;
-  }
-  .photo-label a {
-    color: #555;
-    text-decoration: none;
-    border-bottom: 1px dotted #aaa;
-  }
-  .photo-label a:hover {
-    color: #1a6;
-    border-bottom-color: #1a6;
-  }
-  .obs-link {
-    font-size: 0.7rem;
-    color: #888;
-    text-decoration: none;
-    margin-left: 0.25rem;
-  }
-  .obs-link:hover {
-    color: #1a6;
-  }
-  .photo-wrap {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-  }
   .loading, .error {
     padding: 1rem;
     text-align: center;
@@ -103,74 +52,19 @@
   .error {
     color: #b00;
   }
-  /* Modal */
-  dialog.lightbox {
-    border: 0;
-    padding: 0;
-    background: transparent;
-    max-width: 95vw;
-    max-height: 95vh;
-  }
-  dialog.lightbox::backdrop {
-    background: rgba(0, 0, 0, 0.85);
-  }
-  dialog.lightbox .modal-inner {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    color: #fff;
-    text-align: center;
-  }
-  dialog.lightbox img {
-    max-width: 95vw;
-    max-height: 80vh;
-    border-radius: 6px;
-    background: #222;
-  }
-  dialog.lightbox .caption {
-    margin-top: 0.5rem;
-    font-size: 0.95rem;
-    color: #fff;
-    text-shadow: 0 1px 2px rgba(0,0,0,0.6);
-    max-width: 95vw;
-  }
-  dialog.lightbox .close {
-    position: fixed;
-    top: 12px;
-    right: 16px;
-    background: rgba(0,0,0,0.5);
-    color: #fff;
-    border: 0;
-    font-size: 1.5rem;
-    line-height: 1;
-    padding: 0.4rem 0.7rem;
-    border-radius: 6px;
-    cursor: pointer;
-  }
 </style>
+<script src="image-gallery-component.js" defer></script>
 </head>
 <body>
 <h1>iNaturalist Sightings</h1>
 <div class="meta" id="meta"></div>
 <div id="container"><div class="loading">Loading sightings…</div></div>
 
-<dialog id="lightbox" class="lightbox">
-  <button class="close" id="lightboxClose" aria-label="Close">×</button>
-  <div class="modal-inner">
-    <img id="lightboxImg" alt="">
-    <div class="caption" id="lightboxCaption"></div>
-  </div>
-</dialog>
-
 <script>
 const DATA_URL = "https://raw.githubusercontent.com/simonw/inaturalist-clumps/refs/heads/main/clumps.json";
 
 const container = document.getElementById("container");
 const metaEl = document.getElementById("meta");
-const lightbox = document.getElementById("lightbox");
-const lightboxImg = document.getElementById("lightboxImg");
-const lightboxCaption = document.getElementById("lightboxCaption");
-const lightboxClose = document.getElementById("lightboxClose");
 
 function speciesNameFor(observation) {
   const taxon = observation.taxon || {};
@@ -239,81 +133,36 @@ function renderClump(clump) {
 
   div.appendChild(header);
 
-  const photos = document.createElement("div");
-  photos.className = "photos";
+  const gallery = document.createElement("image-gallery");
 
   for (const obs of clump.observations || []) {
     const name = speciesNameFor(obs);
     for (const photo of obs.photos || []) {
-      const wrap = document.createElement("div");
-      wrap.className = "photo-wrap";
+      const figure = document.createElement("figure");
 
-      const btn = document.createElement("button");
-      btn.className = "photo";
-      btn.type = "button";
+      const a = document.createElement("a");
+      a.href = photo.large_url;
 
       const img = document.createElement("img");
       const smallUrl = (photo.thumbnail_url || "").replace(/\/medium\.(jpe?g|png)(\?.*)?$/i, "/small.$1$2");
       img.src = smallUrl || photo.thumbnail_url;
       img.loading = "lazy";
       img.alt = name;
-      img.title = name;
 
-      btn.appendChild(img);
-      btn.addEventListener("click", () => {
-        openLightbox(photo.large_url, name, obs.uri);
-      });
+      a.appendChild(img);
+      figure.appendChild(a);
 
-      const label = document.createElement("div");
-      label.className = "photo-label";
-      if (obs.uri) {
-        const a = document.createElement("a");
-        a.href = obs.uri;
-        a.target = "_blank";
-        a.rel = "noopener";
-        a.textContent = name;
-        a.title = "View observation on iNaturalist";
-        label.appendChild(a);
-      } else {
-        label.textContent = name;
-      }
+      const figcaption = document.createElement("figcaption");
+      figcaption.textContent = name;
+      figure.appendChild(figcaption);
 
-      wrap.appendChild(btn);
-      wrap.appendChild(label);
-      photos.appendChild(wrap);
+      gallery.appendChild(figure);
     }
   }
 
-  div.appendChild(photos);
+  div.appendChild(gallery);
   return div;
 }
-
-function openLightbox(largeUrl, name, uri) {
-  lightboxImg.src = largeUrl;
-  lightboxImg.alt = name;
-  lightboxCaption.innerHTML = "";
-  const nameLine = document.createElement("div");
-  nameLine.textContent = name;
-  nameLine.style.fontWeight = "600";
-  lightboxCaption.appendChild(nameLine);
-  if (uri) {
-    const link = document.createElement("a");
-    link.href = uri;
-    link.target = "_blank";
-    link.rel = "noopener";
-    link.textContent = "View on iNaturalist";
-    link.style.color = "#9cf";
-    const linkLine = document.createElement("div");
-    linkLine.appendChild(link);
-    lightboxCaption.appendChild(linkLine);
-  }
-  lightbox.showModal();
-}
-
-lightboxClose.addEventListener("click", () => lightbox.close());
-lightbox.addEventListener("click", (e) => {
-  if (e.target === lightbox) lightbox.close();
-});
 
 async function load() {
   try {

--- a/inat-sightings.html
+++ b/inat-sightings.html
@@ -153,7 +153,17 @@ function renderClump(clump) {
       figure.appendChild(a);
 
       const figcaption = document.createElement("figcaption");
-      figcaption.textContent = name;
+      if (obs.uri) {
+        const link = document.createElement("a");
+        link.href = obs.uri;
+        link.target = "_blank";
+        link.rel = "noopener";
+        link.textContent = name;
+        link.title = "View observation on iNaturalist";
+        figcaption.appendChild(link);
+      } else {
+        figcaption.textContent = name;
+      }
       figure.appendChild(figcaption);
 
       gallery.appendChild(figure);


### PR DESCRIPTION
Saves a cleaned-up image-gallery-component.js (the gist export had
arrived with smart quotes, en-dashes in CSS variables, ellipsis spread
operators, and stray markdown triple backticks). Switches
inat-sightings.html to use the new component for each clump's photos,
removing the now-redundant custom lightbox markup, styles, and code.

https://claude.ai/code/session_01BArryzUYbt8tqHmC3KCp3j