### PR TITLE
Add markdown rendering support for slide text

### DIFF
--- a/big-words.html
+++ b/big-words.html
@@ -47,7 +47,6 @@
         text-align: center;
         line-height: 1.05;
         word-break: break-word;
-        white-space: pre-wrap;
         max-width: 100%;
         font-weight: 800;
         font-size: 12vmin;
@@ -320,9 +319,39 @@
     const form = $('form');
     const hint = $('hint');
 
+    function escapeHtml(s) {
+        const div = document.createElement('div');
+        div.textContent = s;
+        return div.innerHTML;
+    }
+
+    function renderInlineMarkdown(line) {
+        const SENTINEL = String.fromCharCode(0xE000);
+        const tokens = [];
+        const stash = (value) => {
+            tokens.push(value);
+            return SENTINEL + (tokens.length - 1) + SENTINEL;
+        };
+        let s = escapeHtml(line);
+        s = s.replace(/\\([\\*_`])/g, (_, ch) => stash(ch));
+        s = s.replace(/`([^`\n]+)`/g, (_, code) => stash('<code>' + code + '</code>'));
+        s = s.replace(/\*\*([^*\n]+?)\*\*/g, '<strong>$1</strong>');
+        s = s.replace(/\*([^*\n]+?)\*/g, '<em>$1</em>');
+        s = s.replace(/_([^_\n]+?)_/g, '<u>$1</u>');
+        return s.replace(
+            new RegExp(SENTINEL + '(\\d+)' + SENTINEL, 'g'),
+            (_, i) => tokens[+i]
+        );
+    }
+
+    function renderMarkdown(text) {
+        return text.split('\n').map(renderInlineMarkdown).join('<br>');
+    }
+
     function applyFromState(state) {
         const text = state.text || '';
-        words.textContent = state.uppercase === '1' ? text.toUpperCase() : text;
+        const transformed = state.uppercase === '1' ? text.toUpperCase() : text;
+        words.innerHTML = renderMarkdown(transformed);
 
         document.body.style.color = state.color;
         if (state.gradient === '1') {


### PR DESCRIPTION
## Summary
This PR adds inline markdown rendering capabilities to the slide text display, allowing users to format text with bold, italic, underline, and code styling.

## Key Changes
- **Removed `white-space: pre-wrap`** CSS property from the text styling to allow proper text wrapping with the new markdown rendering
- **Added `escapeHtml()` function** to safely escape HTML special characters in user input before processing
- **Added `renderInlineMarkdown()` function** that processes inline markdown syntax:
  - `**text**` for bold (`<strong>`)
  - `*text*` for italic (`<em>`)
  - `_text_` for underline (`<u>`)
  - `` `text` `` for code (`<code>`)
  - Supports escaping special characters with backslash (`\*`, `\_`, etc.)
- **Added `renderMarkdown()` function** that splits text by newlines and applies inline markdown rendering to each line, joining them with `<br>` tags
- **Updated `applyFromState()`** to use `innerHTML` with the new markdown renderer instead of `textContent`, enabling formatted text display

## Implementation Details
The markdown rendering uses a token stashing approach with a Unicode sentinel character (U+E000) to safely handle escaped characters and code blocks without interference from subsequent regex replacements. This ensures that content within code blocks and escaped characters are preserved exactly as intended.

https://claude.ai/code/session_01A6bDUnVTwZZ5D7gZPmb1Xo