### PR TITLE
llm-cliche-highlighter: add “worth naming” pattern

### DIFF
--- a/llm-cliche-highlighter.html
+++ b/llm-cliche-highlighter.html
@@ -553,6 +553,12 @@ const patterns = [
     name: '“The punchline is”',
     description: '“The punchline is …”, “the punchline:”, or “the punchline?”.',
     find: makeRegexFinder(/\bthe\s+punchline(?:\s+(?:is|was|being)\b|\s*[:?])/gi)
+  },
+  {
+    id: 'worth-naming',
+    name: '“Worth naming”',
+    description: 'The therapist-voiced “that loss is real and it’s worth naming”, “it’s worth naming that …”, or a “Worth naming:” opener. Skips “naming names”.',
+    find: makeRegexFinder(/(?:\b(?:is|are|was|were|feels?|felt|seems?|seemed)|['\u2019]s)\s+(?:\w+\s+){0,2}?worth\s+naming\b(?!\s+names\b)|\bworth\s+naming\s*:/gi)
   }
 ];
 
@@ -668,7 +674,7 @@ const EXAMPLE = `We rebuilt the editor from the ground up. No sign-ups, no downl
 
 The reviewer read the draft twice. Did not flinch, did not blink, did not reach for the red pen. That's the whole review, honestly.
 
-Don't call it a rewrite — call it a rescue. The improvement is real, and it's not subtle. Sit with that for a moment.
+Don't call it a rewrite — call it a rescue. The improvement is real, and it's not subtle. That loss is worth naming. Sit with that for a moment.
 
 You already know the answer, of course. Consistency is the entire game, and the punchline is that nobody wants to hear it. The entire pitch is one sentence long.
 
@@ -1049,7 +1055,15 @@ const patternCases = [
   ['punchline', 'The punchline is that nobody laughed.', 1],
   ['punchline', 'The punchline: nothing changed.', 1],
   ['punchline', 'And the punchline? You knew.', 1],
-  ['punchline', 'He forgot the punchline entirely.', 0]
+  ['punchline', 'He forgot the punchline entirely.', 0],
+  ['worth-naming', "That loss is real and it's worth naming.", 1],
+  ['worth-naming', 'It’s worth naming that this hurts.', 1],
+  ['worth-naming', 'The grief here is worth naming.', 1],
+  ['worth-naming', 'That anger feels worth naming out loud.', 1],
+  ['worth-naming', 'Worth naming: nobody asked for this.', 1],
+  ['worth-naming', "It's not worth naming names here.", 0],
+  ['worth-naming', 'They spent the meeting naming the new mascot.', 0],
+  ['worth-naming', 'The naming convention is worth documenting.', 0]
 ];
 
 for (const [id, sample, expectMatches, expectItems] of patternCases) {


### PR DESCRIPTION
> New LLM cliche: "‪That loss is real and it's worth naming‬" - tell me what pattern you'll add before you add it

Adds a new cliché pattern to the LLM cliché highlighter: **“Worth naming”** (id `worth-naming`) — the therapist-voiced validation move, as in *“That loss is real and it’s worth naming.”*

```js
/(?:\b(?:is|are|was|were|feels?|felt|seems?|seemed)|['’]s)\s+(?:\w+\s+){0,2}?worth\s+naming\b(?!\s+names\b)|\bworth\s+naming\s*:/gi
```

Details:

- Anchors on a linking verb (`is/are/was/were/feels/seems/'s`) plus up to two filler words before “worth naming”, so “it’s worth naming”, “is real and worth naming”, “the grief here is worth naming”, and “feels worth naming out loud” all match, along with the standalone “Worth naming:” opener.
- A negative lookahead skips “naming names” — a different, human idiom.
- On the canonical example sentence, the existing “Is real … and” pattern independently flags the “is real and” half, so the full cliché double-highlights.
- Adds 5 positive and 3 negative test cases, plus a sentence in the built-in example text that trips the new pattern exactly once, preserving the “example trips every pattern exactly once” test invariant.

All 73 self-tests pass headlessly via the Node one-liner in the page footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpUUmMbM1zhwtjk5i4MkEy

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpUUmMbM1zhwtjk5i4MkEy)_