### PR TITLE
Add "that's not nothing" cliche to LLM cliche highlighter

### DIFF
--- a/llm-cliche-highlighter.html
+++ b/llm-cliche-highlighter.html
@@ -559,6 +559,12 @@ const patterns = [
     name: '“Worth naming”',
     description: 'The therapist-voiced “that loss is real and it’s worth naming”, “it’s worth naming that …”, or a “Worth naming:” opener. Skips “naming names”.',
     find: makeRegexFinder(/(?:\b(?:is|are|was|were|feels?|felt|seems?|seemed)|['\u2019]s)\s+(?:\w+\s+){0,2}?worth\s+naming\b(?!\s+names\b)|\bworth\s+naming\s*:/gi)
+  },
+  {
+    id: 'not-nothing',
+    name: '\u201cThat\u2019s not nothing\u201d',
+    description: '\u201cThat is not nothing\u201d / \u201cthat\u2019s not nothing\u201d, plus the \u201cthis / it / which is not nothing\u201d variants.',
+    find: makeRegexFinder(/\b(?:that|this|it|which)(?:['\u2019]s|\s+(?:is|was))\s+not\s+nothing\b/gi)
   }
 ];
 
@@ -674,7 +680,7 @@ const EXAMPLE = `We rebuilt the editor from the ground up. No sign-ups, no downl
 
 The reviewer read the draft twice. Did not flinch, did not blink, did not reach for the red pen. That's the whole review, honestly.
 
-Don't call it a rewrite — call it a rescue. The improvement is real, and it's not subtle. That loss is worth naming. Sit with that for a moment.
+Don't call it a rewrite — call it a rescue. The improvement is real, and it's not subtle. That loss is worth naming. Sit with that for a moment. The gains were modest, but that's not nothing.
 
 You already know the answer, of course. Consistency is the entire game, and the punchline is that nobody wants to hear it. The entire pitch is one sentence long.
 
@@ -1063,7 +1069,13 @@ const patternCases = [
   ['worth-naming', 'Worth naming: nobody asked for this.', 1],
   ['worth-naming', "It's not worth naming names here.", 0],
   ['worth-naming', 'They spent the meeting naming the new mascot.', 0],
-  ['worth-naming', 'The naming convention is worth documenting.', 0]
+  ['worth-naming', 'The naming convention is worth documenting.', 0],
+  ['not-nothing', "That's not nothing.", 1],
+  ['not-nothing', 'Ten sign-ups in a week — that is not nothing.', 1],
+  ['not-nothing', "It's not nothing, even if it's not everything.", 1],
+  ['not-nothing', 'The launch drew a small crowd, which was not nothing.', 1],
+  ['not-nothing', 'She insisted that nothing was wrong.', 0],
+  ['not-nothing', 'There is nothing left to say.', 0]
 ];
 
 for (const [id, sample, expectMatches, expectItems] of patternCases) {


### PR DESCRIPTION
Detects "that is not nothing" / "that's not nothing" and the
this / it / which variants.

Prompted by https://twitter.com/fedesco5/status/2078279414370955393

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JxEQ6aToWuTsDZJyq4KDUG