### PR TITLE
Add direct fetch fallback for URL loading with race condition

### DIFF
--- a/llm-cliche-highlighter.html
+++ b/llm-cliche-highlighter.html
@@ -688,6 +688,8 @@ This closing paragraph is deliberately ordinary, with no list patterns at all, s
 
 // URL loading: the page URL's #fragment holds the article URL, and the text is
 // fetched through the Jina Reader proxy (https://r.jina.ai/) as plain text.
+// A direct fetch of the URL races alongside as a quiet fallback in case the
+// site serves open CORS headers and Jina fails.
 
 function normalizeUrl(raw) {
   const url = raw.trim();
@@ -795,12 +797,27 @@ urlForm.addEventListener('submit', async event => {
   history.replaceState(null, '', fragmentFromUrl(url));
   loadUrlBtn.disabled = true;
   setUrlStatus('Fetching ' + url + ' via r.jina.ai …');
-  try {
-    const response = await fetch('https://r.jina.ai/' + url, {
-      headers: { 'X-Return-Format': 'text' }
-    });
+  const fetchText = async (target, options) => {
+    const response = await fetch(target, options);
     if (!response.ok) throw new Error('HTTP ' + response.status);
-    const text = await response.text();
+    return response.text();
+  };
+  const jinaPromise = fetchText('https://r.jina.ai/' + url, {
+    headers: { 'X-Return-Format': 'text' }
+  });
+  const directPromise = fetchText(url);
+  directPromise.catch(() => {});
+  try {
+    let text;
+    try {
+      text = await jinaPromise;
+    } catch (jinaErr) {
+      try {
+        text = await directPromise;
+      } catch (directErr) {
+        throw jinaErr;
+      }
+    }
     input.value = text;
     run();
     setUrlStatus('Loaded ' + text.length.toLocaleString() + ' characters from ' + url);


### PR DESCRIPTION
> Modify llm-cliche-highlighter - when it loads a URL have it fire off two requests in parallel, one to the jina thing and one to the URL directly (on the off-chance that it supports open CORS headers)
> 
> If both return favor the Jina one. If the Jina one returns an HTTP status error of any sort and the CORS one does not, use the CORS one. If both fail then show an error. Don't make a big deal out of this, just quietly use the CORS fetch as backup for if Jina fails.

## Summary
Enhanced the URL loading mechanism to implement a race condition between Jina Reader proxy and direct fetch, allowing the page to load content even if Jina fails but the target site has open CORS headers.

## Key Changes
- Refactored fetch logic into a reusable `fetchText()` helper function that handles HTTP error checking
- Implemented dual-fetch strategy: Jina Reader proxy as primary method with direct fetch as silent fallback
- Added try-catch nesting to attempt Jina first, then fall back to direct fetch if Jina fails
- Direct fetch runs in parallel (via `Promise` race semantics) but silently catches errors to avoid noise
- Updated code comments to document the new fallback behavior

## Implementation Details
- Both fetch requests are initiated simultaneously to minimize latency
- The direct fetch promise has its rejection explicitly caught and suppressed (`.catch(() => {})`) to prevent unhandled rejection warnings
- Error handling prioritizes Jina errors but will throw them only if both methods fail
- The fallback gracefully handles CORS restrictions on the target site by catching and ignoring those errors

https://claude.ai/code/session_014q3Z2gAqr6XZxMkQBTaoem