### PR TITLE
bluesky-firehose: fix dead endpoint, upgrade to Jetstream v2, mobile-friendly UI

### DIFF
--- a/bluesky-firehose.html
+++ b/bluesky-firehose.html
@@ -72,31 +72,71 @@
     </div>
 
     <script>
+        // Public Jetstream instances - some can accept connections but stream
+        // no data, so connect() falls back to the next one if nothing arrives
+        const endpoints = [
+            'jetstream1.us-east.bsky.network',
+            'jetstream2.us-east.bsky.network',
+            'jetstream1.us-west.bsky.network',
+            'jetstream2.us-west.bsky.network'
+        ];
+        const firstMessageTimeoutMs = 5000;
+
         let ws = null;
+        let firstMessageTimer = null;
         const output = document.getElementById('output');
         const input = document.getElementById('input');
         const jsonError = document.getElementById('jsonError');
-        
+
         function log(message) {
             const timestamp = new Date().toISOString();
             output.value += `[${timestamp}] ${message}\n`;
             output.scrollTop = output.scrollHeight;
         }
 
-        function connect() {
+        function connect(endpointIndex = 0) {
             if (ws) {
                 log('Already connected!');
                 return;
             }
 
+            if (endpointIndex >= endpoints.length) {
+                log('All Jetstream instances failed - giving up');
+                return;
+            }
+
+            const host = endpoints[endpointIndex];
+            let gotMessage = false;
+            let fallingBack = false;
+
+            function tryNext(reason) {
+                fallingBack = true;
+                clearTimeout(firstMessageTimer);
+                log(`${reason} - trying next instance`);
+                const dead = ws;
+                ws = null;
+                if (dead && dead.readyState !== WebSocket.CLOSED) {
+                    dead.close();
+                }
+                connect(endpointIndex + 1);
+            }
+
             try {
-                ws = new WebSocket('wss://jetstream2.us-east.bsky.network/subscribe?wantedCollections=app.bsky.feed.post');
-                
+                log(`Connecting to ${host}...`);
+                ws = new WebSocket(`wss://${host}/subscribe?wantedCollections=app.bsky.feed.post`);
+
                 ws.onopen = () => {
-                    log('Connected to Bluesky WebSocket');
+                    log(`Connected to ${host}`);
+                    firstMessageTimer = setTimeout(() => {
+                        if (!gotMessage && !fallingBack) {
+                            tryNext(`No data from ${host} after ${firstMessageTimeoutMs / 1000}s`);
+                        }
+                    }, firstMessageTimeoutMs);
                 };
 
                 ws.onmessage = (event) => {
+                    gotMessage = true;
+                    clearTimeout(firstMessageTimer);
                     try {
                         const data = JSON.parse(event.data);
                         log(`Received: ${JSON.stringify(data, null, 2)}`);
@@ -105,11 +145,19 @@
                     }
                 };
 
-                ws.onerror = (error) => {
-                    log(`WebSocket Error: ${error.message}`);
+                ws.onerror = () => {
+                    log(`WebSocket error on ${host}`);
                 };
 
                 ws.onclose = () => {
+                    if (fallingBack) {
+                        return;
+                    }
+                    clearTimeout(firstMessageTimer);
+                    if (!gotMessage && ws) {
+                        tryNext(`Connection to ${host} closed before any data arrived`);
+                        return;
+                    }
                     log('Disconnected from Bluesky WebSocket');
                     ws = null;
                 };
@@ -122,8 +170,10 @@
 
         function disconnect() {
             if (ws) {
-                ws.close();
+                clearTimeout(firstMessageTimer);
+                const socket = ws;
                 ws = null;
+                socket.close();
                 log('Disconnected by user');
             } else {
                 log('Not connected');
@@ -157,7 +207,7 @@
         }
 
         // Event Listeners
-        document.getElementById('connect').addEventListener('click', connect);
+        document.getElementById('connect').addEventListener('click', () => connect());
         document.getElementById('disconnect').addEventListener('click', disconnect);
         document.getElementById('clear').addEventListener('click', () => {
             output.value = '';

--- a/bluesky-firehose.html
+++ b/bluesky-firehose.html
@@ -16,10 +16,12 @@
         }
         textarea {
             width: 100%;
+            box-sizing: border-box;
             height: 200px;
             margin-top: 10px;
             padding: 10px;
             font-family: monospace;
+            font-size: 16px;
             border: 1px solid #ccc;
             border-radius: 4px;
         }
@@ -28,21 +30,45 @@
         }
         .controls {
             margin: 20px 0;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
         }
         button {
-            padding: 8px 16px;
-            margin-right: 10px;
+            padding: 10px 16px;
             cursor: pointer;
+        }
+        pre {
+            overflow-x: auto;
         }
         .error {
             color: red;
             margin-top: 5px;
             font-size: 14px;
         }
+        @media (max-width: 600px) {
+            body {
+                margin: 10px auto;
+                padding: 0 10px;
+            }
+            h1 {
+                font-size: 1.4em;
+            }
+            textarea {
+                height: 150px;
+            }
+            #output {
+                height: 50vh;
+            }
+            .controls button {
+                flex: 1 1 auto;
+            }
+        }
     </style>
 </head>
 <body>
     <h1>Bluesky WebSocket Feed Monitor</h1>
+    <p>Streams live posts from <a href="https://bsky.network/docs/jetstream">Jetstream v2</a> — see also the <a href="https://atproto.com/blog/introducing-bluesky-protocol-services">Bluesky Protocol Services announcement</a>.</p>
     <div class="controls">
         <button id="connect">Connect</button>
         <button id="disconnect">Disconnect</button>
@@ -72,16 +98,12 @@
     </div>
 
     <script>
-        // Public Jetstream instances, v2 first with legacy v1 as fallback -
-        // some can accept connections but stream no data, so connect() falls
-        // back to the next one if nothing arrives
+        // Public Jetstream v2 instances - an instance can accept connections
+        // but stream no data, so connect() falls back to the next one if
+        // nothing arrives
         const endpoints = [
             'jetstream.us-east.bsky.network',
-            'jetstream.us-west.bsky.network',
-            'jetstream1.us-east.bsky.network',
-            'jetstream2.us-east.bsky.network',
-            'jetstream1.us-west.bsky.network',
-            'jetstream2.us-west.bsky.network'
+            'jetstream.us-west.bsky.network'
         ];
         const firstMessageTimeoutMs = 5000;
 

--- a/bluesky-firehose.html
+++ b/bluesky-firehose.html
@@ -72,9 +72,12 @@
     </div>
 
     <script>
-        // Public Jetstream instances - some can accept connections but stream
-        // no data, so connect() falls back to the next one if nothing arrives
+        // Public Jetstream instances, v2 first with legacy v1 as fallback -
+        // some can accept connections but stream no data, so connect() falls
+        // back to the next one if nothing arrives
         const endpoints = [
+            'jetstream.us-east.bsky.network',
+            'jetstream.us-west.bsky.network',
             'jetstream1.us-east.bsky.network',
             'jetstream2.us-east.bsky.network',
             'jetstream1.us-west.bsky.network',

--- a/bluesky-firehose.html
+++ b/bluesky-firehose.html
@@ -10,6 +10,19 @@
             max-width: 800px;
             margin: 20px auto;
             padding: 0 20px;
+            color: #1f2733;
+            background: #f7f9fc;
+            line-height: 1.5;
+        }
+        h1 {
+            color: #1185fe;
+            letter-spacing: -0.02em;
+        }
+        h3 {
+            margin-bottom: 4px;
+        }
+        a {
+            color: #1185fe;
         }
         .textarea-container {
             margin: 20px 0;
@@ -20,10 +33,16 @@
             height: 200px;
             margin-top: 10px;
             padding: 10px;
-            font-family: monospace;
+            font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
             font-size: 16px;
-            border: 1px solid #ccc;
-            border-radius: 4px;
+            color: #1f2733;
+            background: #fff;
+            border: 1px solid #d5dce6;
+            border-radius: 8px;
+        }
+        textarea:focus {
+            outline: 2px solid #1185fe;
+            outline-offset: -1px;
         }
         #output {
             height: 400px;
@@ -35,14 +54,38 @@
             gap: 10px;
         }
         button {
-            padding: 10px 16px;
+            padding: 10px 18px;
             cursor: pointer;
+            font-size: 15px;
+            color: #1f2733;
+            background: #fff;
+            border: 1px solid #d5dce6;
+            border-radius: 8px;
+            transition: background 0.15s, border-color 0.15s;
+        }
+        button:hover {
+            background: #eef4fd;
+            border-color: #1185fe;
+        }
+        #connect, #send {
+            color: #fff;
+            background: #1185fe;
+            border-color: #1185fe;
+        }
+        #connect:hover, #send:hover {
+            background: #0d6ddb;
+            border-color: #0d6ddb;
         }
         pre {
             overflow-x: auto;
+            padding: 10px;
+            font-size: 14px;
+            background: #eef2f7;
+            border: 1px solid #d5dce6;
+            border-radius: 8px;
         }
         .error {
-            color: red;
+            color: #c0392b;
             margin-top: 5px;
             font-size: 14px;
         }


### PR DESCRIPTION
> https://tools.simonwillison.net/bluesky-firehose doesn’t work, figure out why not. Did they change the API it uses?

> https://atproto.com/blog/introducing-bluesky-protocol-services says there’s a new version

> Stop the v1 fallbacks then - and update the UI to link to docs for v2 - also make the UI a bit more responsive on mobile

> Make it a tiny bit prettier

<details><summary>Fable 5 PR</summary>

## Why the tool was broken

The page was hardcoded to `wss://jetstream2.us-east.bsky.network`, which currently **accepts WebSocket connections but never sends any events** — the handshake completes (101 Switching Protocols) and then the stream sits silent forever. Protocol-level testing showed the other public Jetstream instances streaming data within seconds while this one delivered 0 bytes. The Jetstream API itself had not changed.

## Changes

- **Endpoint fallback logic**: `connect()` now walks a list of Jetstream instances, moving to the next one when a connection errors, closes before any data arrives, or opens but delivers no message within 5 seconds (the exact silent-failure mode that broke the tool). The log shows which instance is in use. Also fixed the Connect button passing its click event into `connect()`.
- **Jetstream v2**: Bluesky's [Protocol Services launch](https://atproto.com/blog/introducing-bluesky-protocol-services) introduced consolidated v2 endpoints at `jetstream.us-east.bsky.network` and `jetstream.us-west.bsky.network`. Verified they are drop-in compatible: same `/subscribe` query parameters, same unauthenticated access, same event JSON, and `options_update` subscriber messages still work (tested by switching a live v2 connection from posts to likes). The endpoint list now contains only the two v2 instances; legacy v1 instances were dropped.
- **Docs links**: The page now links to the [Jetstream v2 docs](https://bsky.network/docs/jetstream) and the Protocol Services announcement.
- **Mobile-friendly layout**: wrapping flexbox controls with full-width buttons on small screens, `box-sizing: border-box` on textareas so they don't overflow the viewport, 16px textarea font to prevent iOS Safari zoom-on-focus, horizontal scrolling for the example code block, and tighter spacing plus a 50vh log output under 600px.

## Testing

- Raw WebSocket tests through a proxy confirmed v2 endpoints stream immediately and `options_update` filtering works.
- Headless Chromium checks at 390px and 1024px widths: no horizontal page overflow, controls and log render correctly; fallback logic observed advancing cleanly through instances with sensible log output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014acKDTPNLLk3iknch2Dsp5

</details>

https://claude.ai/code/session_014acKDTPNLLk3iknch2Dsp5