### PR TITLE
Fix the two failing tests on main

### DIFF
--- a/ocr.html
+++ b/ocr.html
@@ -5,9 +5,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script defer data-domain="tools.simonwillison.net" src="https://plausible.io/js/script.js"></script>
   <script type="module">
-  import pdfjsDist from 'https://cdn.jsdelivr.net/npm/pdfjs-dist@4.2.67/+esm';
-  pdfjsLib.GlobalWorkerOptions.workerSrc =
-  "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.2.67/build/pdf.worker.min.mjs";
+  // Import the package's own ESM build rather than jsdelivr's "+esm" bundle,
+  // and publish it ourselves - relying on the bundle to set a global was
+  // fragile and stopped working.
+  window.pdfjsLibReady = import(
+    'https://cdn.jsdelivr.net/npm/pdfjs-dist@4.2.67/build/pdf.min.mjs'
+  ).then((pdfjsLib) => {
+    pdfjsLib.GlobalWorkerOptions.workerSrc =
+      "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.2.67/build/pdf.worker.min.mjs";
+    window.pdfjsLib = pdfjsLib;
+    return pdfjsLib;
+  });
   </script>
   <script src="https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/tesseract.min.js"></script>
 <style>
@@ -411,6 +419,8 @@ document.addEventListener('paste', (event) => {
 
 async function convertPDFToImages(file) {
   // returns { numPages, imageIterator }
+  // Wait for the PDF.js module script, which may still be loading
+  const pdfjsLib = await window.pdfjsLibReady;
   const pdf = await pdfjsLib.getDocument(URL.createObjectURL(file)).promise;
   const numPages = pdf.numPages;
   async function* images() {

--- a/test_microquickjs.py
+++ b/test_microquickjs.py
@@ -1,23 +1,52 @@
 #!/usr/bin/env python3
 """Test script for microquickjs.html using playwright-python"""
 
+import pathlib
+import socket
 import subprocess
 import time
 import sys
+import urllib.error
+import urllib.request
 from playwright.sync_api import sync_playwright
 
+root = pathlib.Path(__file__).parent.absolute()
 
-def test_microquickjs():
+
+def find_unused_port():
+    """Find and return an unused port number on localhost."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+    finally:
+        sock.close()
+
+
+def wait_until_ready(port, server):
+    """Block until the HTTP server answers, for up to 5 seconds."""
+    for _ in range(50):
+        time.sleep(0.1)
+        if server.poll() is not None:
+            raise RuntimeError(f"Server exited early: {server.communicate()[1]}")
+        try:
+            urllib.request.urlopen(f"http://127.0.0.1:{port}/", timeout=1)
+            return
+        except (urllib.error.URLError, ConnectionRefusedError):
+            continue
+    raise RuntimeError("Server did not become ready in time")
+
+
+def test_microquickjs(wasm_param=""):
     # Start a simple HTTP server in the background
+    port = find_unused_port()
     server = subprocess.Popen(
-        ["python3", "-m", "http.server", "8765"],
-        cwd="/home/user/tools",
+        [sys.executable, "-m", "http.server", str(port), "--directory", str(root)],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        text=True,
     )
-
-    # Give server time to start
-    time.sleep(1)
+    wait_until_ready(port, server)
 
     console_messages = []
     try:
@@ -30,12 +59,8 @@ def test_microquickjs():
             page.on("pageerror", lambda err: console_messages.append(f"[PAGE ERROR] {err}"))
 
             # Navigate to the page - test with wasm param if provided
-            import sys
-            wasm_param = ""
-            if len(sys.argv) > 1 and sys.argv[1] == "original":
-                wasm_param = "?wasm=original"
             print(f"Loading microquickjs.html{wasm_param}...")
-            page.goto(f"http://localhost:8765/microquickjs.html{wasm_param}")
+            page.goto(f"http://127.0.0.1:{port}/microquickjs.html{wasm_param}")
 
             # Wait for the page to initialize (wait for "Run Code" button to be enabled)
             print("Waiting for MicroQuickJS to initialize...")
@@ -127,20 +152,25 @@ factorial(5)"""
             print("\n" + "="*50)
             print("All tests passed! ✓")
             print("="*50)
-            return True
 
     except Exception as e:
+        # Print the console output for debugging, then let the failure
+        # propagate so pytest reports it
         print(f"\n✗ Test failed with error: {e}")
         if console_messages:
             print("\nConsole output:")
             for msg in console_messages:
                 print(f"  {msg}")
-        return False
+        raise
     finally:
         server.terminate()
         server.wait()
 
 
 if __name__ == "__main__":
-    success = test_microquickjs()
-    sys.exit(0 if success else 1)
+    param = "?wasm=original" if len(sys.argv) > 1 and sys.argv[1] == "original" else ""
+    try:
+        test_microquickjs(param)
+    except Exception:
+        sys.exit(1)
+    sys.exit(0)


### PR DESCRIPTION
ocr.html: PDF pages no longer rendered

The module script imported jsdelivr's "+esm" bundle of pdfjs-dist but then
referred to a global `pdfjsLib` that the import statement never declared.
That global was only ever set as a side effect of the bundle, and it is no
longer set, so every PDF upload threw "pdfjsLib is not defined" and rendered
zero pages. Image OCR was unaffected, which is why only test_open_pdf failed.

Import the package's own build/pdf.min.mjs instead and publish the namespace
ourselves. convertPDFToImages now awaits the module, which also closes the
race where a PDF dropped before the module finished loading would fail.

test_microquickjs.py: hardcoded absolute path

The server was started with cwd="/home/user/tools", a path that only existed
on the machine where the test was written, so it failed with FileNotFoundError
everywhere else. Serve the directory containing the test instead, and pick an
unused port rather than a fixed 8765.

Also stop swallowing failures: the test caught every exception and returned
False, which pytest reports as a pass. Re-raise after printing the captured
console output.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LhKecnhycghN3DELjvcQh8