### PR TITLE
cors-chat: fix conversation bar layout on mobile

### DIFF
--- a/cors-chat.html
+++ b/cors-chat.html
@@ -238,7 +238,7 @@
     .conversation-bar.active { display: flex; }
     .conversation-heading { min-width: 0; margin-right: auto; }
     .conversation-heading strong { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-    .conversation-heading span { color: var(--muted); font-size: 12px; }
+    .conversation-heading span { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--muted); font-size: 12px; }
 
     .transcript {
       overflow-y: auto;
@@ -512,6 +512,9 @@
       .conversation-item { min-width: 210px; margin: 0; }
       .sidebar-empty { width: 100%; padding: 8px 10px; text-align: left; }
       .transcript { min-width: 0; }
+      .conversation-bar { flex-wrap: wrap; row-gap: 7px; padding: 9px 12px; }
+      .conversation-heading { flex: 1 1 100%; margin-right: 0; }
+      .conversation-bar .button { flex: 1 1 auto; padding: 7px 9px; font-size: 13px; }
       .message-list { padding: 22px 15px 44px; }
       .message { grid-template-columns: 1fr; gap: 6px; }
       .message-label { text-align: left; }


### PR DESCRIPTION
The Copy Markdown button made the conversation bar's three buttons
squeeze the heading to a sliver on narrow screens, wrapping the meta
line word-by-word. Ellipsize the meta line like the title, and on small
screens wrap the bar so the heading gets its own full-width row with
the buttons below it.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WLaDaQJjq7ymoHdXh9KvNx