### PR TITLE
Add 'Wrap each line in backticks' option to text indentation tool

### DIFF
--- a/text-indentation.html
+++ b/text-indentation.html
@@ -86,6 +86,14 @@ button.hidden {
   display: none;
 }
 
+button.backticks {
+  background: #ff9500;
+}
+
+button.backticks:hover {
+  background: #d97d00;
+}
+
 button.copy {
   background: #5856d6;
 }
@@ -112,6 +120,7 @@ button.copy.success {
     <button id="removeTrailing" class="remove">Remove trailing whitespace</button>
     <button id="quote" class="quote">Quote</button>
     <button id="unquote" class="remove hidden">Unquote</button>
+    <button id="wrapBackticks" class="backticks">Wrap each line in backticks</button>
     <button id="copy" class="copy">Copy to clipboard</button>
   </div>
 </div>
@@ -126,6 +135,7 @@ const remove4Btn = document.getElementById('remove4');
 const quoteBtn = document.getElementById('quote');
 const unquoteBtn = document.getElementById('unquote');
 const removeTrailingBtn = document.getElementById('removeTrailing');
+const wrapBackticksBtn = document.getElementById('wrapBackticks');
 const copyBtn = document.getElementById('copy');
 
 function updateQuoteButtons() {
@@ -223,6 +233,34 @@ removeTrailingBtn.addEventListener('click', () => {
   const text = textInput.value;
   const lines = text.split('\n');
   const processed = lines.map(line => line.replace(/\s+$/, '')).join('\n');
+  textInput.value = processed;
+  updateQuoteButtons();
+});
+
+// Wrap each non-empty line in backticks so it renders as monospaced text
+// but still wraps. Single newlines inside a paragraph get a trailing <br>
+// so Markdown keeps the line break; blank lines separate paragraphs and
+// are left alone because Markdown already handles those.
+function wrapLineInBackticks(line) {
+  // Use a longer fence if the line itself contains backticks
+  const runs = line.match(/`+/g) || [];
+  const longest = runs.reduce((max, run) => Math.max(max, run.length), 0);
+  const fence = '`'.repeat(longest + 1);
+  const pad = longest > 0 ? ' ' : '';
+  return fence + pad + line + pad + fence;
+}
+
+wrapBackticksBtn.addEventListener('click', () => {
+  const text = textInput.value;
+  const lines = text.split('\n');
+  const processed = lines.map((line, i) => {
+    if (line.trim().length === 0) {
+      return line;
+    }
+    const next = lines[i + 1];
+    const nextIsInParagraph = next !== undefined && next.trim().length > 0;
+    return wrapLineInBackticks(line) + (nextIsInParagraph ? '<br>' : '');
+  }).join('\n');
   textInput.value = processed;
   updateQuoteButtons();
 });


### PR DESCRIPTION
> Add an option to the text indentation tool. labeled "wrap each line in backticks"
> 
> It adds a leading and trailing ` to every line of text, such that it will render in monospaced but still wrap
> 
> This also needs to be paragraph aware. The following:
> 
> ```
> This is some text.
> 
> - item
> - item 2
> 
> Short line
> Followed be another
> 
> Final paragraph
> ```
> 
> Should turn into:
> 
> ```
> `This is some text.`
> 
> `- item`<br>
> `- item 2`
> 
> `Short line`<br>
> `Followed be another`
> 
> `Final paragraph`
> ```
> 
> Note how double new lines are fine - markdown handles those correctly - but single newlines need a <br> to display correctly 

https://claude.ai/code/session_01EA2bbM1RGTbDAYNofeoaAK