### PR TITLE
openai_image.py: add -i/--image to edit an existing image from a path or URL

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -208,20 +208,37 @@ Generate an image from a text prompt using OpenAI's image models.
 uv run https://tools.simonwillison.net/python/openai_image.py \
   'A racoon eating cheese wearing an inappropriate hat'
 ```
+Pass `-i/--image` with a file path or URL to an existing image to edit that image instead. The option can be repeated to provide multiple reference images:
+
+```bash
+uv run https://tools.simonwillison.net/python/openai_image.py \
+  'Add a racoon eating cheese wearing an inappropriate hat' \
+  -i photo.jpg -m gpt-image-1
+```
 Use `--help` to see all available options:
 
 ```
 Usage: openai_image.py [OPTIONS] PROMPT OUTFILE
 
-  Generate an image with OpenAI image models.
+  Generate an image with OpenAI image models, or edit an existing image passed
+  with -i/--image.
 
   Positional args:   PROMPT   Text prompt describing the image to generate.
   OUTFILE  Output file path (default: /tmp/image-XXXXXX.png)
 
 Options:
-  -m, --model TEXT                Model to use (known: dall-e-2, dall-e-3,
-                                  gpt-image-1, gpt-image-1-mini)  [default:
+  -i, --image PATH_OR_URL         Existing image to edit (file path or URL).
+                                  May be repeated to supply multiple reference
+                                  images. When given, the prompt is applied as
+                                  an edit using the images.edit endpoint.
+  -m, --model TEXT                Model to use (known: gpt-image-1, gpt-
+                                  image-1-mini, gpt-image-2, gpt-
+                                  image-2-2026-04-21, gpt-image-1.5, chatgpt-
+                                  image-latest, dall-e-2, dall-e-3)  [default:
                                   gpt-image-1-mini]
+  --size TEXT                     size (known: auto, 1024x1024, 1536x1024,
+                                  1024x1536, 256x256, 512x512, 1792x1024,
+                                  1024x1792)
   --background [transparent|opaque|auto]
                                   background.
   --moderation [low|auto]         moderation.
@@ -229,8 +246,7 @@ Options:
                                   output format.
   --quality [standard|hd|low|medium|high|auto]
                                   quality.
-  --size [auto|1024x1024|1536x1024|1024x1536|256x256|512x512|1792x1024|1024x1792]
-                                  size.
+  --input-fidelity [high|low]     input fidelity (only used with --image).
   -h, --help                      Show this message and exit.
 ```
 ## codex_to_markdown.py

--- a/python/openai_image.py
+++ b/python/openai_image.py
@@ -9,6 +9,8 @@ Generate an image with OpenAI’s image models (Click CLI).
 
 - PROMPT is required.
 - OUTFILE is optional; defaults to /tmp/image-<6-hex>.png.
+- -i/--image (repeatable) takes a file path or URL to an existing image; when
+  given, the prompt is applied as an edit to that image via `images.edit`.
 - Flags are auto-derived by introspecting `OpenAI().images.generate` using
   typing.get_type_hints(include_extras=True), so Literal[...] choices appear
   in --help.
@@ -18,10 +20,13 @@ Generate an image with OpenAI’s image models (Click CLI).
 """
 
 import json
+import mimetypes
 import os
 import secrets
 import sys
 import time
+import urllib.parse
+import urllib.request
 import typing as t
 import types as pytypes
 import typing_extensions as tx
@@ -107,9 +112,42 @@ def literal_choices(annotation) -> list[str]:
     return out
 
 
+# ----------------------------- Input images -----------------------------
+
+_IMAGE_EXTS = {"image/png": ".png", "image/jpeg": ".jpg", "image/webp": ".webp"}
+
+
+def load_input_image(ref: str) -> tuple[str, bytes, str]:
+    """Load an image from a local path or an http(s) URL.
+
+    Returns a (filename, bytes, content_type) tuple suitable for the SDK.
+    """
+    if ref.startswith(("http://", "https://")):
+        req = urllib.request.Request(ref, headers={"User-Agent": "openai_image.py"})
+        try:
+            with urllib.request.urlopen(req) as r:
+                data = r.read()
+                ctype = (r.headers.get_content_type() or "").lower()
+        except Exception as e:
+            raise click.BadParameter(f"could not fetch {ref}: {e}", param_hint="--image")
+        name = os.path.basename(urllib.parse.urlsplit(ref).path) or "image"
+        if not ctype.startswith("image/"):
+            ctype = mimetypes.guess_type(name)[0] or "image/png"
+        if not os.path.splitext(name)[1]:
+            name += _IMAGE_EXTS.get(ctype, ".png")
+        return name, data, ctype
+    path = Path(ref).expanduser()
+    if not path.is_file():
+        raise click.BadParameter(f"file not found: {ref}", param_hint="--image")
+    ctype = mimetypes.guess_type(path.name)[0] or "image/png"
+    return path.name, path.read_bytes(), ctype
+
+
 # ----------------------------- CLI construction -----------------------------
 
 PARAMS = ["background", "moderation", "output_format", "quality"]
+# Parameters accepted by images.edit but not images.generate
+EDIT_ONLY_PARAMS = ["input_fidelity"]
 
 
 def build_command() -> click.Command:
@@ -117,6 +155,9 @@ def build_command() -> click.Command:
     images_mod_globals = sys.modules[Images.__module__].__dict__
     hints = get_type_hints(
         Images.generate, globalns=images_mod_globals, include_extras=True
+    )
+    edit_hints = get_type_hints(
+        Images.edit, globalns=images_mod_globals, include_extras=True
     )
 
     # model choices are “known” but we don’t enforce them; we just show in help
@@ -135,6 +176,20 @@ def build_command() -> click.Command:
             required=False,
             type=click.Path(dir_okay=False, writable=True, path_type=Path),
             metavar="OUTFILE",
+        )
+    )
+
+    # -i/--image (repeatable): file path or URL to an existing image to edit
+    params.append(
+        click.Option(
+            ["-i", "--image", "images"],
+            multiple=True,
+            metavar="PATH_OR_URL",
+            help=(
+                "Existing image to edit (file path or URL). May be repeated to "
+                "supply multiple reference images. When given, the prompt is "
+                "applied as an edit using the images.edit endpoint."
+            ),
         )
     )
 
@@ -180,6 +235,19 @@ def build_command() -> click.Command:
                 click.Option([f"--{name.replace('_','-')}"], help=f"{label}.")
             )
 
+    # Edit-only options (e.g. --input-fidelity), choices from images.edit Literals
+    for name in EDIT_ONLY_PARAMS:
+        ann = edit_hints.get(name)
+        label = name.replace("_", " ")
+        choices = literal_choices(ann) if ann is not None else []
+        params.append(
+            click.Option(
+                [f"--{name.replace('_','-')}"],
+                type=click.Choice(choices, case_sensitive=True) if choices else None,
+                help=f"{label} (only used with --image).",
+            )
+        )
+
     @click.pass_context
     def callback(ctx: click.Context, **kw):
         if not os.getenv("OPENAI_API_KEY"):
@@ -187,6 +255,7 @@ def build_command() -> click.Command:
 
         prompt: str = kw.pop("prompt")
         outfile: Path | None = kw.pop("outfile", None)
+        images: tuple[str, ...] = kw.pop("images", ())
         model: str = kw.pop("model")
         size: str | None = kw.pop("size", None)
 
@@ -204,11 +273,42 @@ def build_command() -> click.Command:
             if v is not None:
                 gen_kwargs[p] = v
 
+        if images:
+            # Edit mode: drop params images.edit does not accept, add edit-only ones
+            edit_params = signature(Images.edit).parameters
+            for p in list(gen_kwargs):
+                if p not in edit_params:
+                    click.secho(
+                        f"Warning: --{p.replace('_', '-')} is not supported with "
+                        "--image, ignoring",
+                        fg="red",
+                        err=True,
+                    )
+                    gen_kwargs.pop(p)
+            for p in EDIT_ONLY_PARAMS:
+                v = kw.get(p, None)
+                if v is not None:
+                    gen_kwargs[p] = v
+            loaded = [load_input_image(ref) for ref in images]
+            gen_kwargs["image"] = loaded[0] if len(loaded) == 1 else loaded
+        else:
+            for p in EDIT_ONLY_PARAMS:
+                if kw.get(p, None) is not None:
+                    click.secho(
+                        f"Warning: --{p.replace('_', '-')} only applies with "
+                        "--image, ignoring",
+                        fg="red",
+                        err=True,
+                    )
+
         client = OpenAI()
 
         # ---- timing just the generation call ----
         t0 = time.perf_counter()
-        resp = client.images.generate(prompt=prompt, **gen_kwargs)
+        if images:
+            resp = client.images.edit(prompt=prompt, **gen_kwargs)
+        else:
+            resp = client.images.generate(prompt=prompt, **gen_kwargs)
         t1 = time.perf_counter()
         generation_time = float(t1 - t0)
         # -----------------------------------------
@@ -236,7 +336,8 @@ def build_command() -> click.Command:
         params=params,
         callback=callback,
         help=(
-            "Generate an image with OpenAI image models.\n\n"
+            "Generate an image with OpenAI image models, or edit an existing "
+            "image passed with -i/--image.\n\n"
             "Positional args:\n"
             "  PROMPT   Text prompt describing the image to generate.\n"
             "  OUTFILE  Output file path (default: /tmp/image-XXXXXX.png)\n"


### PR DESCRIPTION
> `I want "Run this: uv run https://tools.simonwillison.net/python/openai_image.py \
  'Add a racoon eating cheese wearing an inappropriate hat' -m gpt-image-2.5-sunburst" to grow an extra option for feeding in a file path or URL to an existing image`

When one or more -i/--image values are supplied the prompt is sent to
images.edit instead of images.generate. Each value may be a local file
path or an http(s) URL. Also adds --input-fidelity (edit only) and warns
about options the edit endpoint does not accept, such as --moderation.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L8h3oaw6d4jqwKs8AKo6UN