### PR TITLE
Normalize non-breaking spaces to regular spaces in markdown

### DIFF
--- a/rich-text-to-markdown.html
+++ b/rich-text-to-markdown.html
@@ -629,6 +629,10 @@ function outputMarkdown() {
 }
 
 function setMarkdown(md) {
+  // Rich pastes from web pages and word processors often carry non-breaking
+  // spaces (U+00A0), typically around links. They look identical to normal
+  // spaces but survive into the markdown, so turn them into plain spaces.
+  md = md.replace(/\u00a0/g, " ");
   currentMarkdown = md;
   const hasContent = md.trim().length > 0;
 


### PR DESCRIPTION
> Update rich-text-to-markdown.html to automatically turn those into spaces

## Summary
This change normalizes non-breaking spaces (U+00A0) to regular spaces when markdown content is set, preventing invisible formatting issues that arise from rich paste operations.

## Key Changes
- Added normalization logic in `setMarkdown()` function to replace all non-breaking spaces with regular spaces before processing markdown content
- Includes explanatory comment documenting why this normalization is necessary

## Implementation Details
Rich text pastes from web pages and word processors often contain non-breaking spaces, particularly around links. These characters are visually identical to regular spaces but are encoded differently (U+00A0 vs U+0020), causing them to persist in the markdown output and potentially cause unexpected formatting behavior. The fix uses a simple regex replacement (`/\u00a0/g`) to convert all non-breaking spaces to standard spaces during markdown ingestion.

https://claude.ai/code/session_01RJNkGJKgW62ufUSZdZz48j